### PR TITLE
Add single-node blockchain to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Build
         run: yarn run build
 
+      - name: Bootstrap chain tests dependencies
+        run : ./scripts/ci/install-chain-tests-deps.sh
+
       # TO-DO: Uncomment when tests are ready to be run on CI (such as those in issues #129-#131)
       # - name: Test
       #  run: yarn test:ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,29 @@ jobs:
       - name: Bootstrap chain tests dependencies
         run : ./scripts/ci/install-chain-tests-deps.sh
 
+      # This step starts a single-node blockchain with a short block period.
+      # Node RPC endpoint is http://localhost:8732
+      - name: Start chain
+        env:
+          LOCAL_CHAIN_IN_BACKGROUND: true
+      # When a new Tezos protocol is activated on mainnet, the corresponding
+      # testnet name should be updated below
+        run: ./local-chain/run-local-chain.sh jakartanet
+
+      # This step exposes following environment variables:
+      # * env.TREASURY_DAO_ADDRESS
+      # * env.REGISTRY_DAO_ADDRESS
+      # * env.DUMMY_FA2_ADDRESS - 'KT' address, used as a governance token address in DAO contracts
+      # * env.DUMMY_GUARDIAN_ADDRESS - 'KT' address, used as a guardian address in DAO contracts
+      # * env.ADMIN_ADDRESS - 'tz' address, used as an admin address in DAO contracts and have large amount of XTZ
+
+      # Step example that use on of these addresses:
+      # - name: Echo addresses
+      #   run: echo "${{ env.ADMIN_ADDRESS }}"
+      - name: Fetch and deploy contracts
+        run: |
+          ./scripts/ci/deploy-contracts.sh
+
       # TO-DO: Uncomment when tests are ready to be run on CI (such as those in issues #129-#131)
       # - name: Test
       #  run: yarn test:ci

--- a/scripts/ci/baseDAO.json
+++ b/scripts/ci/baseDAO.json
@@ -1,0 +1,4 @@
+{ "repo": "https://github.com/tezos-commons/baseDAO.git",
+  "branch" : "master",
+  "rev": "4658a05a545c9fa8eb7a7b817ab79591ed11c3a3"
+}

--- a/scripts/ci/contracts/dummy_fa2.tz
+++ b/scripts/ci/contracts/dummy_fa2.tz
@@ -1,0 +1,24 @@
+parameter (or
+            (or
+              (pair %balance_of (list %requests (pair (address %owner) (nat %token_id))) (contract %callback (list (pair (pair %request (address %owner) (nat %token_id)) (nat %balance)))))
+              (list %transfer (pair (address %from_) (list %txs (pair (address %to_) (nat %token_id) (nat %amount))))))
+            (list %update_operators (or
+                                     (pair %add_operator (address %owner)
+                                                         (address %operator)
+                                                         (nat %token_id))
+                                     (pair %remove_operator (address %owner)
+                                                            (address %operator)
+                                                            (nat %token_id)))));
+storage (list (list (pair (address %from_) (list %txs (pair (address %to_) (nat %token_id) (nat %amount))))));
+code { CAST (pair
+              (or
+                (or
+                  (pair (list (pair address nat))
+                        (contract (list (pair (pair address nat) nat))))
+                  (list (pair address (list (pair address nat nat)))))
+                (list (or (pair address address nat) (pair address address nat))))
+              (list (list (pair address (list (pair address nat nat)))))) ;
+       UNPAIR ;
+       IF_LEFT { IF_LEFT { DROP } { CONS } } { DROP } ;
+       NIL operation ;
+       PAIR }

--- a/scripts/ci/contracts/dummy_guardian.tz
+++ b/scripts/ci/contracts/dummy_guardian.tz
@@ -1,0 +1,9 @@
+parameter (pair address bytes);
+storage unit;
+code { UNPAIR ;
+       UNPAIR ;
+       CONTRACT %drop_proposal bytes ;
+       IF_NONE
+         { DROP ; NIL operation }
+         { SWAP ; PUSH mutez 0 ; SWAP ; TRANSFER_TOKENS ; NIL operation ; SWAP ; CONS } ;
+       PAIR }

--- a/scripts/ci/deploy-contracts.sh
+++ b/scripts/ci/deploy-contracts.sh
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+cwd="$(cd "$(dirname "$0")" &> /dev/null && pwd)"
+repo="$(jq -r .repo < "$cwd/baseDAO.json")"
+branch="$(jq -r .branch < "$cwd/baseDAO.json")"
+rev="$(jq -r .rev < "$cwd/baseDAO.json")"
+
+function get_address_by_alias() {
+    alias="$1"
+    tezos-client list known contracts | grep "$alias" | cut -d' ' -f2
+}
+
+function originate_contract() {
+    alias="$1"
+    src="$2"
+    storage="$3"
+    tezos-client originate contract "$alias" transferring 0 from baker running "$src" --init "$storage" --burn-cap 10
+    get_address_by_alias "$1"
+}
+
+git clone --single-branch --branch "$branch" "$repo"
+cd baseDAO && git checkout "$rev"
+make out/baseDAO.tz
+
+originate_contract "dummyFA2" "$cwd/contracts/dummy_fa2.tz" "{}"
+DUMMY_FA2_ADDRESS="$(get_address_by_alias dummyFA2)"
+originate_contract "dummyGuardian" "$cwd/contracts/dummy_guardian.tz" "Unit"
+DUMMY_GUARDIAN_ADDRESS="$(get_address_by_alias dummyGuardian)"
+ADMIN_ADDRESS=$(get_address_by_alias baker)
+
+make out/treasuryDAO_storage.tz \
+    admin_address="$ADMIN_ADDRESS" \
+    guardian_address="$DUMMY_GUARDIAN_ADDRESS" \
+    governance_token_address="$DUMMY_FA2_ADDRESS" \
+    governance_token_id=0n \
+    start_level=0n
+make out/registryDAO_storage.tz \
+    admin_address="$ADMIN_ADDRESS" \
+    guardian_address="$DUMMY_GUARDIAN_ADDRESS" \
+    governance_token_address="$DUMMY_FA2_ADDRESS" \
+    governance_token_id=0n \
+    start_level=0n
+
+tezos-client originate contract treasuryDAO transferring 0 from baker running out/baseDAO.tz \
+    --init "$(<out/treasuryDAO_storage.tz)" --burn-cap 10
+tezos-client originate contract registryDAO transferring 0 from baker running out/baseDAO.tz \
+    --init "$(<out/treasuryDAO_storage.tz)" --burn-cap 10
+TREASURY_DAO_ADDRESS="$(get_address_by_alias treasuryDAO)"
+REGISTRY_DAO_ADDRESS="$(get_address_by_alias registryDAO)"
+
+echo "TREASURY_DAO_ADDRESS=$TREASURY_DAO_ADDRESS" >> $GITHUB_ENV
+echo "REGISTRY_DAO_ADDRESS=$REGISTRY_DAO_ADDRESS" >> $GITHUB_ENV
+echo "DUMMY_FA2_ADDRESS=$DUMMY_FA2_ADDRESS" >> $GITHUB_ENV
+echo "DUMMY_GUARDIAN_ADDRESS=$DUMMY_GUARDIAN_ADDRESS" >> $GITHUB_ENV
+echo "ADMIN_ADDRESS=$ADMIN_ADDRESS" >> $GITHUB_ENV

--- a/scripts/ci/install-chain-tests-deps.sh
+++ b/scripts/ci/install-chain-tests-deps.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND="noninteractive"
+sudo apt-get update && sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y ppa:serokell/tezos && sudo apt-get update
+sudo apt-get install -y tezos-baking git curl jq wget make
+sudo wget -q -P /usr/bin https://gitlab.com/ligolang/ligo/-/jobs/1553142179/artifacts/raw/ligo && sudo chmod +x /usr/bin/ligo
+git clone https://gitlab.com/morley-framework/local-chain.git


### PR DESCRIPTION
This PR adds three new CI steps:
1) Installs prerequisites for running single-node blockchain
2) Starts single-node blockchain with a short block period that is going to be available in subsequent steps.
3) Deploys 4 contracts: dummyFA2, dummyGuardian, treasuryDAO, and registryDAO.
    Exposes addresses of these contracts to the 'GITHUB_ENV', so that they can be used in subsequent steps.
    Also exposes the address of the DAO contracts admin that has a large amount of XTZ.
    
Revision of the baseDAO contracts that are used by the CI is defined in the [`baseDAO.json`](https://github.com/serokell/homebase-app/blob/d136bc34db6ba4f5a11a35710fc2a9d3aa3e69cd/scripts/ci/baseDAO.json).

Dummy implementations of FA2 and guardian contracts are located in [`scripts/ci/contracts`](https://github.com/serokell/homebase-app/tree/d136bc34db6ba4f5a11a35710fc2a9d3aa3e69cd/scripts/ci/contracts)