### PR TITLE
Change Mainnet tezos node to ECAD Labs Node

### DIFF
--- a/src/services/beacon/utils.ts
+++ b/src/services/beacon/utils.ts
@@ -6,7 +6,7 @@ import { Tzip16Module } from "@taquito/tzip16";
 export type Network = "mainnet" | "ghostnet"
 
 export const rpcNodes: Record<Network, string> = {
-  mainnet: "https://mainnet.smartpy.io",
+  mainnet: "https://mainnet.api.tez.ie",
   ghostnet: "https://ghostnet.ecadinfra.com"
 };
 


### PR DESCRIPTION
The previous node from smartpy has crashed 2-3 times in month, and we've been suggested to move to one from ECAD labs for it's reliability

Fixed #344 