### PR TITLE
Switch network to DAO network if opened by url 

### DIFF
--- a/src/modules/explorer/components/NetworkSheet.tsx
+++ b/src/modules/explorer/components/NetworkSheet.tsx
@@ -36,6 +36,7 @@ export const NetworkSheet: React.FC<Props> = props => {
             onClick={() => {
               props.onClose()
               changeNetwork(networkOption)
+              window.location.href = "/explorer"
             }}
           >
             <Grid container justifyContent="center" alignItems="center" style={{ gap: 8 }}>

--- a/src/modules/explorer/pages/DAO/router.tsx
+++ b/src/modules/explorer/pages/DAO/router.tsx
@@ -6,6 +6,7 @@ import { User } from "modules/explorer/pages/User"
 import React, { useContext, useEffect, useState } from "react"
 import { useHistory } from "react-router"
 import { Redirect, Route, RouteProps, Switch, useParams, useRouteMatch } from "react-router-dom"
+import { Network } from "services/beacon"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { useDAO } from "services/indexer/dao/hooks/useDAO"
 import { Navbar } from "../../components/Toolbar"
@@ -43,7 +44,7 @@ enum DAOState {
 
 const DAORouteContent: React.FC = ({ children }) => {
   const daoId = useDAOID()
-  const { tezos, network } = useTezos()
+  const { tezos, network, changeNetwork } = useTezos()
   const { data, error } = useDAO(daoId)
   const [state, setState] = useState<DAOState>(DAOState.FOUND)
   const history = useHistory()
@@ -63,9 +64,9 @@ const DAORouteContent: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (history && data && data.data.network.toLowerCase() !== network.toLowerCase()) {
-      history.push("/explorer")
+      changeNetwork(data.data.network.toLowerCase() as Network)
     }
-  }, [data, history, network])
+  }, [data, history, network, changeNetwork])
 
   return (
     <>

--- a/src/services/beacon/hooks/useTezos.ts
+++ b/src/services/beacon/hooks/useTezos.ts
@@ -88,6 +88,7 @@ export const useTezos = (): WalletConnectReturn => {
         await connect(newNetwork)
       }
       queryClient.resetQueries()
+      location.reload()
     },
     account,
     network


### PR DESCRIPTION
This PR checks for the network of the DAO and if it doesn't match the current network the changeNetwork is called and switched to DAO's network. 

A better solution for future would be to put the network in the network URL and only triggering network switch if user interact with DAO, until then the DAO should work normally. A similar approach is in Issue #259 