### PR TITLE
modal closed after proposal success

### DIFF
--- a/src/modules/explorer/pages/DAOList/components/DAOItem.tsx
+++ b/src/modules/explorer/pages/DAOList/components/DAOItem.tsx
@@ -26,6 +26,7 @@ const Container = styled(Grid)(({ theme }: { theme: Theme }) => ({
   "padding": 32,
   "cursor": "pointer",
   "transition": "0.15s ease-out",
+  "maxWidth": 490,
 
   ["@media (max-width:1335px)"]: {
     minHeight: 130

--- a/src/modules/lite/explorer/pages/CreateProposal/ProposalCreatorModal.tsx
+++ b/src/modules/lite/explorer/pages/CreateProposal/ProposalCreatorModal.tsx
@@ -12,7 +12,7 @@ export const ProposalCreatorModal: React.FC<any> = ({ open, handleClose }) => {
       title={"Create Off Chain Poll"}
       template="xs"
     >
-      <ProposalCreator />
+      <ProposalCreator onClose={handleClose} />
     </ResponsiveDialog>
   )
 }

--- a/src/modules/lite/explorer/pages/CreateProposal/index.tsx
+++ b/src/modules/lite/explorer/pages/CreateProposal/index.tsx
@@ -531,7 +531,7 @@ const calculateEndTime = (days: number, hours: number, minutes: number) => {
   return String(time.valueOf())
 }
 
-export const ProposalCreator: React.FC<{ id?: string }> = props => {
+export const ProposalCreator: React.FC<{ id?: string; onClose?: any }> = props => {
   const navigate = useHistory()
   const { network, account, wallet } = useTezos()
   const openNotification = useNotification()
@@ -588,6 +588,7 @@ export const ProposalCreator: React.FC<{ id?: string }> = props => {
             variant: "success"
           })
           setIsLoading(false)
+          props.onClose()
           daoId
             ? navigate.push(`/explorer/dao/${daoId}/proposals`)
             : navigate.push(`/explorer/lite/dao/${id}/community`)


### PR DESCRIPTION
Closes #620 

The user cannot be directly redirected to the new proposal after being created - The backend does not return the proposal id. This is how it's working on Lite as well, so I'm copying the behaviour. 