### PR TITLE
Fixed Token count display

### DIFF
--- a/src/modules/explorer/components/DAOStatsRow.tsx
+++ b/src/modules/explorer/components/DAOStatsRow.tsx
@@ -72,6 +72,8 @@ export const DAOStatsRow: React.FC = () => {
   const { data: executableProposals } = useProposals(daoId, ProposalStatus.EXECUTABLE)
   const { hours, minutes, days } = useTimeLeftInCycle()
   const shouldDisable = useIsProposalButtonDisabled(daoId)
+  const tokenDecimals = data?.data.token.decimals || 0
+  const tokenScaleFactor = new BigNumber(10).pow(tokenDecimals)
 
   const amountLocked = useMemo(() => {
     if (!ledger) {
@@ -85,16 +87,15 @@ export const DAOStatsRow: React.FC = () => {
   }, [ledger])
 
   const amountNotLocked = useMemo(() => {
-    if (!data) {
-      return new BigNumber(0)
-    }
-
-    return data.data.token.supply
+    return data?.data.token.supply || new BigNumber(0)
   }, [data])
 
   const totalTokens = amountLocked.plus(amountNotLocked)
 
   const amountLockedPercentage = totalTokens ? amountLocked.div(totalTokens).multipliedBy(100) : new BigNumber(0)
+
+  const totalTokensWithoutDecimals = totalTokens.dividedBy(tokenScaleFactor)
+  const amountLockedWithoutDecimals = amountLocked.dividedBy(tokenScaleFactor)
 
   return (
     <Box sx={{ flexGrow: 1, width: "inherit" }}>
@@ -105,7 +106,7 @@ export const DAOStatsRow: React.FC = () => {
               <ItemTitle color="textPrimary">Total {symbol}</ItemTitle>
             </ItemContent>
             <Grid item>
-              <ItemValue color="textPrimary"> {numbro(totalTokens).format(formatConfig)}</ItemValue>
+              <ItemValue color="textPrimary">{numbro(totalTokensWithoutDecimals).format(formatConfig)}</ItemValue>
             </Grid>
           </Item>
         </Grid>
@@ -115,7 +116,7 @@ export const DAOStatsRow: React.FC = () => {
               <ItemTitle color="textPrimary">{symbol} Locked</ItemTitle>
             </ItemContent>
             <Grid item container direction="row">
-              <ItemValue color="textPrimary">{numbro(amountLocked).format(formatConfig)}</ItemValue>
+              <ItemValue color="textPrimary">{numbro(amountLockedWithoutDecimals).format(formatConfig)}</ItemValue>
               <Percentage color="textPrimary">{numbro(amountLockedPercentage).format(formatConfig)}%</Percentage>
             </Grid>
           </Item>


### PR DESCRIPTION
Fixes #802 

For displaying the token count, we are now showing it without decimals.

For example, for this particular token
![Screenshot 2024-03-14 at 1 26 01 AM](https://github.com/dOrgTech/homebase-app/assets/7466924/43987aeb-48fb-49d8-bf60-0b3444b45eb1)

The UI now shows information like this
![Screenshot 2024-03-14 at 1 26 31 AM](https://github.com/dOrgTech/homebase-app/assets/7466924/1628f9db-5c4e-4d95-9f17-9092d0687fa5)
