### PR TITLE
updated discord link

### DIFF
--- a/src/modules/common/Footer.tsx
+++ b/src/modules/common/Footer.tsx
@@ -94,7 +94,7 @@ export const ExplorerFooter: React.FC = () => {
   }
 
   const goToDiscord = () => {
-    window.open("https://discord.com/invite/yXaPy6s5Nr", "_blank")
+    window.open("https://discord.gg/autFpNaFYu", "_blank")
   }
 
   const goToYoutube = () => {


### PR DESCRIPTION
The discord link was pointing to the main Tezos blockchain server instead of our Homebase server. Fixed it.