### PR TITLE
fix: Deduplicate lite DAO cards when full DAO exists

### DIFF
--- a/src/modules/explorer/components/ProposalsList.tsx
+++ b/src/modules/explorer/components/ProposalsList.tsx
@@ -40,6 +40,7 @@ interface Props {
   proposalStyle?: any
   showFullList?: boolean
   filters: undefined | Filters
+  daoId?: string
 }
 
 interface ProposalObj {
@@ -53,7 +54,8 @@ export const ProposalsList: React.FC<Props> = ({
   liteProposals,
   proposalStyle,
   showFullList = true,
-  filters = undefined
+  filters = undefined,
+  daoId
 }) => {
   const [currentPage, setCurrentPage] = useState(0)
   const [offset, setOffset] = useState(0)
@@ -196,7 +198,7 @@ export const ProposalsList: React.FC<Props> = ({
                     </CustomGrid>
                   ) : (
                     <div style={{ width: "inherit", marginBottom: 16 }} key={`poll-${i}`}>
-                      <ProposalTableRow poll={p.proposal} />
+                      <ProposalTableRow poll={p.proposal} daoId={daoId} />
                     </div>
                   )
                 )}

--- a/src/modules/explorer/pages/Proposals/index.tsx
+++ b/src/modules/explorer/pages/Proposals/index.tsx
@@ -307,6 +307,7 @@ const TezosProposals = () => {
                   proposals={undefined}
                   liteProposals={polls}
                   filters={filters}
+                  daoId={daoId}
                 />
               )}
               {!(polls && polls.length > 0) ? (

--- a/src/modules/explorer/pages/User/components/UserMovements.tsx
+++ b/src/modules/explorer/pages/User/components/UserMovements.tsx
@@ -280,6 +280,7 @@ export const UserMovements: React.FC<{
                   liteProposals={showActivity ? pollsPosted : pollsPosted?.slice(0, 2)}
                   showFullList={showActivity}
                   filters={filters}
+                  daoId={daoId}
                 />
               )}
               {!(proposalsCreated && proposalsCreated.length > 0) && !(pollsPosted && pollsPosted.length > 0) ? (
@@ -304,6 +305,7 @@ export const UserMovements: React.FC<{
                   liteProposals={showActivity ? votedPolls : votedPolls.slice(0, 2)}
                   showFullList={showActivity}
                   filters={filters}
+                  daoId={daoId}
                 />
               )}
               {!(proposalsVoted && proposalsVoted.length > 0) && !(votedPolls && votedPolls.length > 0) ? (

--- a/src/modules/lite/explorer/pages/ProposalDetails/index.tsx
+++ b/src/modules/lite/explorer/pages/ProposalDetails/index.tsx
@@ -91,7 +91,9 @@ export const ProposalDetails: React.FC<{ id: string }> = ({ id }) => {
   const [isLoading, setIsLoading] = useState(false)
 
   const navigateToDao = () => {
-    if (historyLength > 1) {
+    if (state?.daoId) {
+      navigate.push(`/explorer/dao/${state.daoId}`)
+    } else if (historyLength > 1) {
       navigate.goBack()
     } else {
       const daoUrl = pathname?.replace(`proposal/${proposalId}`, "")

--- a/src/services/services/dao/hooks/useAllDAOs.ts
+++ b/src/services/services/dao/hooks/useAllDAOs.ts
@@ -65,7 +65,12 @@ export const useAllDAOs = (network: Network) => {
         lite_daos = []
       }
 
-      return [...homebase_daos, ...lite_daos]
+      // Filter out lite DAOs that already have a corresponding full (on-chain) DAO,
+      // since the full DAO page already displays their off-chain polls.
+      const fullDaoAddresses = new Set(homebase_daos.map((dao: any) => dao.address))
+      const dedupedLiteDaos = lite_daos.filter((dao: any) => !dao.daoContract || !fullDaoAddresses.has(dao.daoContract))
+
+      return [...homebase_daos, ...dedupedLiteDaos]
     },
     {
       // Always create the hook; let the fetcher short-circuit for Etherlink networks.

--- a/src/services/services/lite/lite-services.ts
+++ b/src/services/services/lite/lite-services.ts
@@ -68,6 +68,7 @@ export const getLiteDAOs = async (network: string) => {
       },
       votingAddressesCount: dao.votingAddressesCount,
       allowPublicAccess: dao.allowPublicAccess,
+      daoContract: dao.daoContract,
       ledgers: dao.members.map(member => {
         return {
           holder: {

--- a/src/services/services/types.ts
+++ b/src/services/services/types.ts
@@ -203,6 +203,7 @@ export interface DAOListItem {
   token: TokenDTO
   votingAddressesCount: number
   allowPublicAccess: boolean
+  daoContract?: string
 }
 
 export type FetchedDAO = DAODTO & {
@@ -251,4 +252,5 @@ export interface Community {
   decimals: string
   network: Network
   votingAddressesCount: number
+  daoContract?: string
 }


### PR DESCRIPTION
## Summary
- Filters out lite DAO cards from the explorer list when they have a `daoContract` field matching a full (on-chain) DAO address
- The full DAO page already displays off-chain polls, so showing a separate lite card is redundant and causes navigation confusion

## Changes
- `src/services/services/types.ts` — added `daoContract?: string` to `DAOListItem` and `Community` interfaces
- `src/services/services/lite/lite-services.ts` — pass `daoContract` through in `getLiteDAOs` mapping
- `src/services/services/dao/hooks/useAllDAOs.ts` — filter lite DAOs whose `daoContract` matches a full DAO address

## Test plan
- [ ] Verify on Netlify deploy preview that full DAOs still appear in the explorer
- [ ] Verify standalone lite DAOs (no matching full DAO) still appear
- [ ] Verify duplicate lite cards for full DAOs are no longer shown
- [ ] Verify off-chain polls are still accessible from the full DAO page