### PR TITLE
chore: resolve shell-quote to 1.8.4 (clears critical CVE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "mipd": "0.0.7",
     "protobufjs": "7.5.8",
     "@noble/hashes": "1.8.0",
-    "dompurify": "3.4.3"
+    "dompurify": "3.4.3",
+    "shell-quote": "1.8.4"
   },
   "overrides": {
     "viem": "2.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16232,10 +16232,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.7.3, shell-quote@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.8.4, shell-quote@^1.7.3, shell-quote@^1.8.3:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

A critical advisory landed on `shell-quote` <1.8.4 (command injection — `quote()` does not escape newlines in object `.op` values). It reaches the tree only through `react-scripts` dev/build tooling:

- `react-scripts > react-dev-utils > shell-quote`
- `react-scripts > webpack-dev-server > launch-editor > shell-quote`

These run only during `yarn start` (local dev) — **not in the production bundle Netlify ships**, so it isn't exploitable by site visitors. Pinned via resolution regardless, to keep the audit clean and the next security report green.

In-range patch bump (1.8.3 → 1.8.4), single copy in the tree.

## Audit impact

| Severity | Before | After |
|---|---|---|
| Critical | 2 | **0** |

(Both criticals were this same `shell-quote` advisory via the two paths above.)

## Test plan

- [x] `yarn install` — clean, single `shell-quote@1.8.4` in tree
- [x] `npx tsc --noEmit` — green
- [x] `yarn audit --level critical` — 0 criticals
- Resolution-only change; no source files touched.