### PR TITLE
refactor: migrate react-query v3 → @tanstack/react-query v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-html-parser": "^2.0.2",
     "react-markdown": "^8.0.0",
     "react-paginate": "^8.2.0",
-    "react-query": "^3.13.0",
     "react-router-dom": "^5.2.0",
     "react-router-hash-link": "^2.4.3",
     "react-scripts": "^5.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import "App.css"
 import { BrowserRouter as Router, Redirect, Route, Switch } from "react-router-dom"
-import { QueryClient, QueryClientProvider } from "react-query"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import { Box, ThemeProvider, styled } from "@material-ui/core"
 import { SnackbarProvider } from "notistack"
@@ -32,7 +32,7 @@ const queryClient = new QueryClient({
       refetchOnMount: false,
       refetchOnWindowFocus: true,
       staleTime: 5000,
-      cacheTime: 300000
+      gcTime: 300000
     }
   }
 })
@@ -82,7 +82,6 @@ const App: React.FC = () => {
           horizontal: "center"
         }}
       >
-        {/* <TanStackQueryClientProvider client={tsQueryClient}> */}
         <QueryClientProvider client={queryClient}>
           <ActionSheetProvider>
             <Box bgcolor="primary.dark" position="absolute" width="100%">
@@ -137,7 +136,6 @@ const App: React.FC = () => {
             </Box>
           </ActionSheetProvider>
         </QueryClientProvider>
-        {/* </TanStackQueryClientProvider> */}
       </SnackbarProvider>
     </ThemeProvider>
   )

--- a/src/modules/etherlink/hooks/useDaoMembers.ts
+++ b/src/modules/etherlink/hooks/useDaoMembers.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { ethers } from "ethers"
 import HbTokenAbi from "assets/abis/hb_evm.json"
 import { getTokenHolders } from "modules/etherlink/utils"
@@ -9,9 +9,9 @@ interface DaoMember {
 }
 
 export const useDaoMembers = (network: string, token: string, decimals: number, provider: any) => {
-  return useQuery<DaoMember[], Error>(
-    ["daoMembers", network, token],
-    async () => {
+  return useQuery<DaoMember[], Error>({
+    queryKey: ["daoMembers", network, token],
+    queryFn: async () => {
       if (!provider || !token || !network) {
         throw new Error("Missing required parameters")
       }
@@ -51,12 +51,10 @@ export const useDaoMembers = (network: string, token: string, decimals: number, 
 
       return results
     },
-    {
-      enabled: !!provider && !!token && !!network,
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      cacheTime: 10 * 60 * 1000, // 10 minutes
-      retry: 2,
-      retryDelay: 1000
-    }
-  )
+    enabled: !!provider && !!token && !!network,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+    retry: 2,
+    retryDelay: 1000
+  })
 }

--- a/src/modules/lite/explorer/hooks/usePolls.tsx
+++ b/src/modules/lite/explorer/hooks/usePolls.tsx
@@ -5,14 +5,14 @@ import { useNotification } from "modules/common/hooks/useNotification"
 import { isProposalActive } from "services/lite/utils"
 import { ProposalStatus } from "../components/ProposalTableRowStatusBadge"
 import { EnvKey, getEnv } from "services/config"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 
 export const usePolls = (id: any) => {
   const openNotification = useNotification()
 
-  const { data, ...rest } = useQuery(
-    ["proposals", id],
-    async () => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["proposals", id],
+    queryFn: async () => {
       const response = await fetch(`${getEnv(EnvKey.REACT_APP_LITE_API_URL)}/polls/${id}/list`)
 
       if (!response.ok) {
@@ -51,12 +51,10 @@ export const usePolls = (id: any) => {
 
       return communityPolls
     },
-    {
-      refetchInterval: 30000,
-      enabled: !!id,
-      refetchOnMount: "always"
-    }
-  )
+    refetchInterval: 30000,
+    enabled: !!id,
+    refetchOnMount: "always"
+  })
 
   return {
     data,

--- a/src/modules/lite/explorer/hooks/useUserVotes.tsx
+++ b/src/modules/lite/explorer/hooks/useUserVotes.tsx
@@ -2,7 +2,7 @@
 import React from "react"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { EnvKey, getEnv } from "services/config"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { Choice } from "models/Choice"
 
@@ -10,9 +10,9 @@ export const useUserVotes = () => {
   const { account } = useTezos()
   const openNotification = useNotification()
 
-  const { data, ...rest } = useQuery(
-    ["userVotes"],
-    async () => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["userVotes"],
+    queryFn: async () => {
       const response = await fetch(`${getEnv(EnvKey.REACT_APP_LITE_API_URL)}/choices/${String(account)}/user_votes`)
 
       if (!response.ok) {
@@ -31,12 +31,10 @@ export const useUserVotes = () => {
       }
       return userVotedPolls
     },
-    {
-      refetchInterval: 30000,
-      enabled: !!account,
-      refetchOnMount: "always"
-    }
-  )
+    refetchInterval: 30000,
+    enabled: !!account,
+    refetchOnMount: "always"
+  })
 
   return {
     data,

--- a/src/services/aci/useArbitratyContractData.ts
+++ b/src/services/aci/useArbitratyContractData.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { Network } from "services/beacon"
@@ -20,8 +20,8 @@ export const useArbitraryContractData = () => {
       finishLoad: (status: boolean) => void
       showHeader: (status: boolean) => void
     }
-  >(
-    async ({ contract, network, handleContinue, finishLoad, showHeader }) => {
+  >({
+    mutationFn: async ({ contract, network, handleContinue, finishLoad, showHeader }) => {
       try {
         let tezosToolkit = tezos
 
@@ -58,10 +58,8 @@ export const useArbitraryContractData = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/agora/hooks/useTopic.tsx
+++ b/src/services/agora/hooks/useTopic.tsx
@@ -1,11 +1,13 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { getTopicById } from "../topics"
 import { Topic } from "../topics/types"
 
 export const useAgoraTopic = (topicId?: number) => {
-  const result = useQuery<Topic, Error>(["agoraTopic", topicId], () => getTopicById(topicId as number), {
+  const result = useQuery<Topic, Error>({
+    queryKey: ["agoraTopic", topicId],
+    queryFn: () => getTopicById(topicId as number),
     enabled: !!topicId,
-    cacheTime: Infinity,
+    gcTime: Infinity,
     refetchOnWindowFocus: false
   })
 

--- a/src/services/beacon/hooks/useTezos.ts
+++ b/src/services/beacon/hooks/useTezos.ts
@@ -1,4 +1,4 @@
-import { useQueryClient } from "react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useCallback, useContext, useEffect } from "react"
 import { TezosToolkit } from "@taquito/taquito"
 import { connectWithBeacon, createTezos, Network, rpcNodes, TezosActionType } from "services/beacon"

--- a/src/services/contracts/baseDAO/hooks/useBlockchainInfo.ts
+++ b/src/services/contracts/baseDAO/hooks/useBlockchainInfo.ts
@@ -1,9 +1,12 @@
 import { getNetworkStats } from "../../../bakingBad/stats"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BlockchainStats } from "../../../bakingBad/stats/types"
 
 export const useBlockchainInfo = () => {
   const { network } = useTezos()
-  return useQuery<BlockchainStats, Error>(["blockchainStats", network], () => getNetworkStats(network))
+  return useQuery<BlockchainStats, Error>({
+    queryKey: ["blockchainStats", network],
+    queryFn: () => getNetworkStats(network)
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useDAOHoldings.ts
+++ b/src/services/contracts/baseDAO/hooks/useDAOHoldings.ts
@@ -1,5 +1,5 @@
 import { BaseDAO } from ".."
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { DAOHolding, getDAOBalances, getDAONFTBalances, NFTDAOHolding } from "services/bakingBad/tokenBalances"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -10,15 +10,13 @@ export const useDAOHoldings = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { network } = useTezos()
 
-  const { data, ...rest } = useQuery<DAOHolding[], Error>(
-    ["balances", contractAddress],
-    async () => {
+  const { data, ...rest } = useQuery<DAOHolding[], Error>({
+    queryKey: ["balances", contractAddress],
+    queryFn: async () => {
       return await getDAOBalances((dao as BaseDAO).data.address, network)
     },
-    {
-      enabled: !!dao
-    }
-  )
+    enabled: !!dao
+  })
 
   const tokens = useMemo(() => {
     if (!data) {
@@ -39,15 +37,13 @@ export const useDAONFTHoldings = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { network } = useTezos()
 
-  const { data, ...rest } = useQuery<DAOHolding[], Error>(
-    ["nftbalances", contractAddress],
-    async () => {
+  const { data, ...rest } = useQuery<DAOHolding[], Error>({
+    queryKey: ["nftbalances", contractAddress],
+    queryFn: async () => {
       return await getDAONFTBalances((dao as BaseDAO).data.address, network)
     },
-    {
-      enabled: !!dao
-    }
-  )
+    enabled: !!dao
+  })
 
   const nfts = useMemo(() => {
     if (!data) {

--- a/src/services/contracts/baseDAO/hooks/useDAOLambda.ts
+++ b/src/services/contracts/baseDAO/hooks/useDAOLambda.ts
@@ -1,5 +1,5 @@
 import { BaseDAO } from ".."
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getDAOLambda } from "services/bakingBad/lambdas"
@@ -9,15 +9,13 @@ export const useDAOLambda = (contractAddress: string, lambda_name: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { network } = useTezos()
 
-  const { data } = useQuery<Lambda, Error>(
-    ["lambdas", contractAddress, lambda_name],
-    async () => {
+  const { data } = useQuery<Lambda, Error>({
+    queryKey: ["lambdas", contractAddress, lambda_name],
+    queryFn: async () => {
       return await getDAOLambda((dao as BaseDAO).data.address, network, lambda_name)
     },
-    {
-      enabled: !!dao
-    }
-  )
+    enabled: !!dao
+  })
 
   return data
 }

--- a/src/services/contracts/baseDAO/hooks/useDAOLambdas.ts
+++ b/src/services/contracts/baseDAO/hooks/useDAOLambdas.ts
@@ -1,5 +1,5 @@
 import { BaseDAO } from ".."
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getDAOLambdas } from "services/bakingBad/lambdas"
@@ -9,15 +9,13 @@ export const useDAOLambdas = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { network } = useTezos()
 
-  const { data } = useQuery<Lambda[], Error>(
-    ["lambdas", contractAddress],
-    async () => {
+  const { data } = useQuery<Lambda[], Error>({
+    queryKey: ["lambdas", contractAddress],
+    queryFn: async () => {
       return await getDAOLambdas((dao as BaseDAO).data.address, network)
     },
-    {
-      enabled: !!dao
-    }
-  )
+    enabled: !!dao
+  })
 
   return data
 }

--- a/src/services/contracts/baseDAO/hooks/useDelegate.ts
+++ b/src/services/contracts/baseDAO/hooks/useDelegate.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getLatestDelegation } from "services/bakingBad/delegations"
@@ -7,9 +7,9 @@ export const useDelegate = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { tezos, network } = useTezos()
 
-  const result = useQuery<{ address: string; alias?: string } | null, Error>(
-    ["daoDelegate", contractAddress],
-    async () => {
+  const result = useQuery<{ address: string; alias?: string } | null, Error>({
+    queryKey: ["daoDelegate", contractAddress],
+    queryFn: async () => {
       const latestDelegation = await getLatestDelegation(contractAddress, network)
 
       if (!latestDelegation) {
@@ -18,10 +18,8 @@ export const useDelegate = (contractAddress: string) => {
 
       return latestDelegation.newDelegate
     },
-    {
-      enabled: !!dao && !!tezos
-    }
-  )
+    enabled: !!dao && !!tezos
+  })
 
   return result
 }

--- a/src/services/contracts/baseDAO/hooks/useDropAllExpired.ts
+++ b/src/services/contracts/baseDAO/hooks/useDropAllExpired.ts
@@ -1,5 +1,5 @@
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -9,8 +9,8 @@ export const useDropAllExpired = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<any | Error, Error, { dao: BaseDAO; expiredProposalIds: string[] }>(
-    async params => {
+  return useMutation<any | Error, Error, { dao: BaseDAO; expiredProposalIds: string[] }>({
+    mutationFn: async params => {
       const { key: dropNotification, closeSnackbar: closeFlushNotification } = openNotification({
         message: "Please sign the transaction to drop all expired proposals",
         persist: true,
@@ -49,10 +49,8 @@ export const useDropAllExpired = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useDropProposal.ts
+++ b/src/services/contracts/baseDAO/hooks/useDropProposal.ts
@@ -1,6 +1,6 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -10,8 +10,8 @@ export const useDropProposal = () => {
   const openNotification = useNotification()
   const { network, tezos, connect, account } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; proposalId: string }>(
-    async params => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; proposalId: string }>({
+    mutationFn: async params => {
       const { key: dropProposal, closeSnackbar: closeDropProposal } = openNotification({
         message: "Please sign the transaction to drop proposal",
         persist: true,
@@ -50,10 +50,8 @@ export const useDropProposal = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useFlush.ts
+++ b/src/services/contracts/baseDAO/hooks/useFlush.ts
@@ -1,5 +1,5 @@
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -10,46 +10,46 @@ export const useFlush = () => {
   const { network, tezos, account, connect } = useTezos()
 
   return useMutation<any | Error, Error, { dao: BaseDAO; numOfProposalsToFlush: number; expiredProposalIds: string[] }>(
-    async params => {
-      const { key: flushNotification, closeSnackbar: closeFlushNotification } = openNotification({
-        message: "Please sign the transaction to flush",
-        persist: true,
-        variant: "info"
-      })
-      try {
-        let tezosToolkit = tezos
-
-        if (!account) {
-          const connectedToolkit = await connect()
-          if (typeof connectedToolkit === "string") {
-            throw new Error("Failed to connect to Tezos toolkit")
-          }
-          tezosToolkit = connectedToolkit
-        }
-
-        const data = await params.dao.flush(params.numOfProposalsToFlush, params.expiredProposalIds, tezosToolkit)
-        closeFlushNotification(flushNotification)
-
-        await data.confirmation(1)
-        openNotification({
-          message: "Execute transaction confirmed!",
-          autoHideDuration: 5000,
-          variant: "success",
-          detailsLink: `https://${networkNameMap[network]}.tzkt.io/` + data.opHash
-        })
-
-        return data
-      } catch (e) {
-        closeFlushNotification(flushNotification)
-        openNotification({
-          message: "An error has happened with execute transaction!",
-          variant: "error",
-          autoHideDuration: 5000
-        })
-        return new Error((e as Error).message)
-      }
-    },
     {
+      mutationFn: async params => {
+        const { key: flushNotification, closeSnackbar: closeFlushNotification } = openNotification({
+          message: "Please sign the transaction to flush",
+          persist: true,
+          variant: "info"
+        })
+        try {
+          let tezosToolkit = tezos
+
+          if (!account) {
+            const connectedToolkit = await connect()
+            if (typeof connectedToolkit === "string") {
+              throw new Error("Failed to connect to Tezos toolkit")
+            }
+            tezosToolkit = connectedToolkit
+          }
+
+          const data = await params.dao.flush(params.numOfProposalsToFlush, params.expiredProposalIds, tezosToolkit)
+          closeFlushNotification(flushNotification)
+
+          await data.confirmation(1)
+          openNotification({
+            message: "Execute transaction confirmed!",
+            autoHideDuration: 5000,
+            variant: "success",
+            detailsLink: `https://${networkNameMap[network]}.tzkt.io/` + data.opHash
+          })
+
+          return data
+        } catch (e) {
+          closeFlushNotification(flushNotification)
+          openNotification({
+            message: "An error has happened with execute transaction!",
+            variant: "error",
+            autoHideDuration: 5000
+          })
+          return new Error((e as Error).message)
+        }
+      },
       onSuccess: () => {
         queryClient.resetQueries()
       }

--- a/src/services/contracts/baseDAO/hooks/useFreeze.ts
+++ b/src/services/contracts/baseDAO/hooks/useFreeze.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js"
 import AnalyticsService from "services/services/analytics"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -17,8 +17,8 @@ export const useFreeze = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<any | Error, Error, Params>(
-    async params => {
+  return useMutation<any | Error, Error, Params>({
+    mutationFn: async params => {
       const { key: freezeNotification, closeSnackbar: closeFreezeNotification } = openNotification({
         message: `${params.freeze ? "Deposit" : "Withdrawal"} is being processed...`,
         persist: true,
@@ -63,10 +63,8 @@ export const useFreeze = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useLambdaAddPropose.ts
+++ b/src/services/contracts/baseDAO/hooks/useLambdaAddPropose.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { LambdaAddArgs } from "../lambdaDAO/types"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -17,8 +17,8 @@ export const useLambdaAddPropose = () => {
     TransactionWalletOperation | Error,
     Error,
     { dao: LambdaDAO; args: LambdaAddArgs; handleClose: () => void }
-  >(
-    async ({ dao, args, handleClose }) => {
+  >({
+    mutationFn: async ({ dao, args, handleClose }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -70,10 +70,8 @@ export const useLambdaAddPropose = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useLambdaExecutePropose.ts
+++ b/src/services/contracts/baseDAO/hooks/useLambdaExecutePropose.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { LambdaExecuteArgs } from "../lambdaDAO/types"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -17,8 +17,8 @@ export const useLambdaExecutePropose = () => {
     TransactionWalletOperation | Error,
     Error,
     { dao: LambdaDAO; args: LambdaExecuteArgs; handleClose: () => void }
-  >(
-    async ({ dao, args, handleClose }) => {
+  >({
+    mutationFn: async ({ dao, args, handleClose }) => {
       // debugger
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
@@ -68,10 +68,8 @@ export const useLambdaExecutePropose = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useLambdaRemovePropose.ts
+++ b/src/services/contracts/baseDAO/hooks/useLambdaRemovePropose.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { LambdaRemoveArgs } from "../lambdaDAO/types"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -17,8 +17,8 @@ export const useLambdaRemovePropose = () => {
     TransactionWalletOperation | Error,
     Error,
     { dao: LambdaDAO; args: LambdaRemoveArgs; handleClose: () => void }
-  >(
-    async ({ dao, args, handleClose }) => {
+  >({
+    mutationFn: async ({ dao, args, handleClose }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -66,10 +66,8 @@ export const useLambdaRemovePropose = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useOriginate.ts
+++ b/src/services/contracts/baseDAO/hooks/useOriginate.ts
@@ -2,7 +2,7 @@ import { OriginateParams } from "../types"
 import { DAOTemplate } from "../../../../modules/creator/state/types"
 import { useState } from "react"
 import { ContractAbstraction, ContractProvider, TezosToolkit, Wallet } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { deployMetadataCarrier } from "services/contracts/metadataCarrier/deploy"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -78,8 +78,8 @@ export const useOriginate = (template: DAOTemplate) => {
   const provider = etherlink.provider
   const signer = etherlink.signer
 
-  const result = useMutation<ContractAbstraction<ContractProvider | Wallet>, Error, OriginateParams>(
-    async ({ metadataParams, params, deploymentMethod }) => {
+  const result = useMutation<ContractAbstraction<ContractProvider | Wallet>, Error, OriginateParams>({
+    mutationFn: async ({ metadataParams, params, deploymentMethod }) => {
       const updatedStates = INITIAL_STATES
 
       let contract
@@ -298,12 +298,10 @@ export const useOriginate = (template: DAOTemplate) => {
 
       return contract
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 
   return { mutation: result, states, activeState }
 }

--- a/src/services/contracts/baseDAO/hooks/useProposeConfigChange.ts
+++ b/src/services/contracts/baseDAO/hooks/useProposeConfigChange.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from "../class"
@@ -13,8 +13,8 @@ export const useProposeConfigChange = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; args: ConfigProposalParams }>(
-    async ({ dao, args }) => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; args: ConfigProposalParams }>({
+    mutationFn: async ({ dao, args }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -59,10 +59,8 @@ export const useProposeConfigChange = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useProposeDelegationChange.ts
+++ b/src/services/contracts/baseDAO/hooks/useProposeDelegationChange.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from "../class"
@@ -12,8 +12,8 @@ export const useProposeDelegationChange = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; newDelegationAddress: string }>(
-    async ({ dao, newDelegationAddress }) => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; newDelegationAddress: string }>({
+    mutationFn: async ({ dao, newDelegationAddress }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -58,10 +58,8 @@ export const useProposeDelegationChange = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useProposeGuardianChange.ts
+++ b/src/services/contracts/baseDAO/hooks/useProposeGuardianChange.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from "../class"
@@ -12,8 +12,8 @@ export const useProposeGuardianChange = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; newGuardianAddress: string }>(
-    async ({ dao, newGuardianAddress }) => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: BaseDAO; newGuardianAddress: string }>({
+    mutationFn: async ({ dao, newGuardianAddress }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -58,10 +58,8 @@ export const useProposeGuardianChange = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useRegistryPropose.ts
+++ b/src/services/contracts/baseDAO/hooks/useRegistryPropose.ts
@@ -1,5 +1,5 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { RegistryProposeArgs } from "../lambdaDAO/types"
 import { useNotification } from "modules/common/hooks/useNotification"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -13,8 +13,8 @@ export const useRegistryPropose = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: LambdaDAO; args: RegistryProposeArgs }>(
-    async ({ dao, args }) => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: LambdaDAO; args: RegistryProposeArgs }>({
+    mutationFn: async ({ dao, args }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Proposal is being created...",
         persist: true,
@@ -60,10 +60,8 @@ export const useRegistryPropose = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useSendXTZ.ts
+++ b/src/services/contracts/baseDAO/hooks/useSendXTZ.ts
@@ -1,7 +1,7 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
 import { BigNumber } from "bignumber.js"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -16,8 +16,8 @@ export const useSendXTZ = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, Params>(
-    async params => {
+  return useMutation<TransactionWalletOperation | Error, Error, Params>({
+    mutationFn: async params => {
       const { key: notification, closeSnackbar: closeNotification } = openNotification({
         message: "XTZ transfer is being processed...",
         persist: true,
@@ -57,10 +57,8 @@ export const useSendXTZ = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useTezosBalance.ts
+++ b/src/services/contracts/baseDAO/hooks/useTezosBalance.ts
@@ -1,5 +1,5 @@
 import { BaseDAO } from ".."
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import BigNumber from "bignumber.js"
@@ -9,16 +9,14 @@ export const useTezosBalance = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { tezos } = useTezos()
 
-  const result = useQuery<BigNumber, Error>(
-    ["tezosBalance", contractAddress],
-    async () => {
+  const result = useQuery<BigNumber, Error>({
+    queryKey: ["tezosBalance", contractAddress],
+    queryFn: async () => {
       const balance = await tezos.tz.getBalance((dao as BaseDAO).data.address)
       return mutezToXtz(new BigNumber(balance.toString()))
     },
-    {
-      enabled: !!dao && !!tezos
-    }
-  )
+    enabled: !!dao && !!tezos
+  })
 
   return result
 }

--- a/src/services/contracts/baseDAO/hooks/useTokenMetadata.ts
+++ b/src/services/contracts/baseDAO/hooks/useTokenMetadata.ts
@@ -1,5 +1,5 @@
 import { Token } from "models/Token"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { getTokenMetadata } from "services/bakingBad/tokenBalances"
 
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -7,13 +7,11 @@ import { useTezos } from "services/beacon/hooks/useTezos"
 export const useTokenMetadata = (address?: string, tokenId?: string) => {
   const { tezos, network } = useTezos()
 
-  const result = useQuery<Token, Error>(
-    ["tokenMetadata", address, tokenId],
-    () => getTokenMetadata(address as string, network, tokenId as string),
-    {
-      enabled: !!tezos && !!address
-    }
-  )
+  const result = useQuery<Token, Error>({
+    queryKey: ["tokenMetadata", address, tokenId],
+    queryFn: () => getTokenMetadata(address as string, network, tokenId as string),
+    enabled: !!tezos && !!address
+  })
 
   return result
 }

--- a/src/services/contracts/baseDAO/hooks/useTransfers.ts
+++ b/src/services/contracts/baseDAO/hooks/useTransfers.ts
@@ -1,5 +1,5 @@
 import { BaseDAO } from ".."
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getDAOTransfers } from "services/bakingBad/transfers"
@@ -32,9 +32,9 @@ export const useTransfers = (contractAddress: string) => {
   const { data: dao } = useDAO(contractAddress)
   const { network } = useTezos()
 
-  const result = useQuery<TransferWithBN[], Error>(
-    ["transfers", contractAddress],
-    async () => {
+  const result = useQuery<TransferWithBN[], Error>({
+    queryKey: ["transfers", contractAddress],
+    queryFn: async () => {
       const tokenTransfersDTO = await getDAOTransfers((dao as BaseDAO).data.address, network)
 
       const xtzTransfersDTO = await getXTZTransfers((dao as BaseDAO).data.address)
@@ -62,10 +62,8 @@ export const useTransfers = (contractAddress: string) => {
 
       return tokenTransfers.concat(xtzTransfers).sort((a, b) => (dayjs(a.date).isAfter(dayjs(b.date)) ? 1 : -1))
     },
-    {
-      enabled: !!dao
-    }
-  )
+    enabled: !!dao
+  })
 
   return result
 }

--- a/src/services/contracts/baseDAO/hooks/useTreasuryPropose.ts
+++ b/src/services/contracts/baseDAO/hooks/useTreasuryPropose.ts
@@ -1,6 +1,6 @@
 import { TransactionWalletOperation } from "@taquito/taquito"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { RegistryProposeArgs } from "../lambdaDAO/types"
 import AnalyticsService from "services/services/analytics"
@@ -13,8 +13,8 @@ export const useTreasuryPropose = () => {
   const openNotification = useNotification()
   const { network, tezos, connect, account } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, { dao: LambdaDAO; args: RegistryProposeArgs }>(
-    async ({ dao, args }) => {
+  return useMutation<TransactionWalletOperation | Error, Error, { dao: LambdaDAO; args: RegistryProposeArgs }>({
+    mutationFn: async ({ dao, args }) => {
       const { key: proposalNotification, closeSnackbar: closeProposalNotification } = openNotification({
         message: "Treasury proposal is being created...",
         persist: true,
@@ -61,10 +61,8 @@ export const useTreasuryPropose = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useUnstakeFromAllProposals.ts
+++ b/src/services/contracts/baseDAO/hooks/useUnstakeFromAllProposals.ts
@@ -1,5 +1,5 @@
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -9,8 +9,8 @@ export const useUnstakeFromAllProposals = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<any | Error, Error, { dao: BaseDAO; allProposals: string[] }>(
-    async params => {
+  return useMutation<any | Error, Error, { dao: BaseDAO; allProposals: string[] }>({
+    mutationFn: async params => {
       const { key: unstakeNotification, closeSnackbar: closeFlushNotification } = openNotification({
         message: "Please sign the transaction to unstake tokens from all proposals",
         persist: true,
@@ -49,10 +49,8 @@ export const useUnstakeFromAllProposals = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useUnstakeVotes.ts
+++ b/src/services/contracts/baseDAO/hooks/useUnstakeVotes.ts
@@ -1,6 +1,6 @@
 import AnalyticsService from "services/services/analytics"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -15,8 +15,8 @@ export const useUnstakeVotes = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<any | Error, Error, Params>(
-    async params => {
+  return useMutation<any | Error, Error, Params>({
+    mutationFn: async params => {
       const { key: freezeNotification, closeSnackbar: closeFreezeNotification } = openNotification({
         message: `Unstake is being processed...`,
         persist: true,
@@ -61,10 +61,8 @@ export const useUnstakeVotes = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/baseDAO/hooks/useVote.ts
+++ b/src/services/contracts/baseDAO/hooks/useVote.ts
@@ -2,7 +2,7 @@ import { TransactionWalletOperation } from "@taquito/taquito"
 import { BigNumber } from "bignumber.js"
 import AnalyticsService from "services/services/analytics"
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { BaseDAO } from ".."
 import { networkNameMap } from "../../../bakingBad"
@@ -19,8 +19,8 @@ export const useVote = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<TransactionWalletOperation | Error, Error, Params>(
-    async params => {
+  return useMutation<TransactionWalletOperation | Error, Error, Params>({
+    mutationFn: async params => {
       const { key: voteNotification, closeSnackbar: closeVoteNotification } = openNotification({
         message: "Vote is being created...",
         persist: true,
@@ -72,10 +72,8 @@ export const useVote = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/etherlinkDAO/hooks/useEvmProposalOps.tsx
+++ b/src/services/contracts/etherlinkDAO/hooks/useEvmProposalOps.tsx
@@ -3,7 +3,7 @@ import { create } from "zustand"
 import { persist } from "zustand/middleware"
 
 import { useCallback, useContext, useMemo, useState } from "react"
-import { useQueryClient } from "react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { EtherlinkContext } from "services/wagmi/context"
 
@@ -893,10 +893,10 @@ export const useEvmProposalOps = () => {
       // ignore optimistic override errors
     }
 
-    queryClient.invalidateQueries(["daoMembers"])
-    queryClient.invalidateQueries(["dao", daoSelected?.address])
-    queryClient.invalidateQueries(["proposals", daoSelected?.address])
-    queryClient.invalidateQueries(["proposal", daoSelected?.address])
+    queryClient.invalidateQueries({ queryKey: ["daoMembers"] })
+    queryClient.invalidateQueries({ queryKey: ["dao", daoSelected?.address] })
+    queryClient.invalidateQueries({ queryKey: ["proposals", daoSelected?.address] })
+    queryClient.invalidateQueries({ queryKey: ["proposal", daoSelected?.address] })
 
     if (daoSelected?.id && network) {
       const firebaseRootCollection = networkConfig[network as keyof typeof networkConfig]?.firebaseRootCollection
@@ -909,10 +909,10 @@ export const useEvmProposalOps = () => {
     }
 
     setTimeout(() => {
-      queryClient.invalidateQueries(["daoMembers"])
-      queryClient.invalidateQueries(["dao", daoSelected?.address])
-      queryClient.invalidateQueries(["proposals", daoSelected?.address])
-      queryClient.invalidateQueries(["proposal", daoSelected?.address])
+      queryClient.invalidateQueries({ queryKey: ["daoMembers"] })
+      queryClient.invalidateQueries({ queryKey: ["dao", daoSelected?.address] })
+      queryClient.invalidateQueries({ queryKey: ["proposals", daoSelected?.address] })
+      queryClient.invalidateQueries({ queryKey: ["proposal", daoSelected?.address] })
 
       if (daoSelected?.id && network) {
         const firebaseRootCollection = networkConfig[network as keyof typeof networkConfig]?.firebaseRootCollection

--- a/src/services/contracts/token/hooks/useDelegationStatus.ts
+++ b/src/services/contracts/token/hooks/useDelegationStatus.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { getTokenDelegation } from "services/bakingBad/delegations"
 import { getDAOBalances } from "services/bakingBad/tokenBalances"
 import { useTezos } from "services/beacon/hooks/useTezos"
@@ -6,19 +6,17 @@ import { useTezos } from "services/beacon/hooks/useTezos"
 export const useDelegationStatus = (tokenAddress: string | undefined) => {
   const { network, tezos, account, connect } = useTezos()
 
-  const { data, ...rest } = useQuery<string | null, Error>(
-    ["tokenDelegations", tokenAddress],
-    async () => {
+  const { data, ...rest } = useQuery<string | null, Error>({
+    queryKey: ["tokenDelegations", tokenAddress],
+    queryFn: async () => {
       if (!tokenAddress) {
         return null
       } else {
         return await getTokenDelegation(tokenAddress, account, network)
       }
     },
-    {
-      enabled: !!tokenAddress && !!account
-    }
-  )
+    enabled: !!tokenAddress && !!account
+  })
 
   return {
     data,

--- a/src/services/contracts/token/hooks/useToken.ts
+++ b/src/services/contracts/token/hooks/useToken.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers"
 import { ContractAbstraction, ContractProvider, TezosToolkit, Wallet } from "@taquito/taquito"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { TokenContractParams } from "modules/creator/deployment/state/types"
@@ -24,8 +24,8 @@ export const useTokenOriginate = (tokenData: TokenContractParams) => {
 
   const openNotification = useNotification()
 
-  const result = useMutation<ContractAbstraction<ContractProvider | Wallet>, Error, TokenContractParams>(
-    async ({ tokenDistribution, tokenSettings }) => {
+  const result = useMutation<ContractAbstraction<ContractProvider | Wallet>, Error, TokenContractParams>({
+    mutationFn: async ({ tokenDistribution, tokenSettings }) => {
       console.log({ tokenDistribution, tokenSettings, network })
 
       if (network.startsWith("etherlink")) {
@@ -110,12 +110,10 @@ export const useTokenOriginate = (tokenData: TokenContractParams) => {
         }
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 
   return { mutation: result }
 }

--- a/src/services/contracts/token/hooks/useTokenDelegate.ts
+++ b/src/services/contracts/token/hooks/useTokenDelegate.ts
@@ -1,5 +1,5 @@
 import { useNotification } from "modules/common/hooks/useNotification"
-import { useMutation, useQueryClient } from "react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { networkNameMap } from "../../../bakingBad"
 import { setDelegate } from ".."
@@ -10,8 +10,8 @@ export const useTokenDelegate = () => {
   const openNotification = useNotification()
   const { network, tezos, account, connect } = useTezos()
 
-  return useMutation<any | Error, Error, { tokenAddress: string; delegateAddress: string | null }>(
-    async params => {
+  return useMutation<any | Error, Error, { tokenAddress: string; delegateAddress: string | null }>({
+    mutationFn: async params => {
       const { tokenAddress, delegateAddress } = params
       // const { key: flushNotification, closeSnackbar: closeFlushNotification } = openNotification({
       //   message: "Please sign the transaction to flush",
@@ -57,10 +57,8 @@ export const useTokenDelegate = () => {
         return new Error((e as Error).message)
       }
     },
-    {
-      onSuccess: () => {
-        queryClient.resetQueries()
-      }
+    onSuccess: () => {
+      queryClient.resetQueries()
     }
-  )
+  })
 }

--- a/src/services/contracts/token/hooks/useTokenDelegationSupported.ts
+++ b/src/services/contracts/token/hooks/useTokenDelegationSupported.ts
@@ -1,24 +1,22 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { isTokenDelegationSupported } from "services/bakingBad/tokenBalances"
 import { useTezos } from "services/beacon/hooks/useTezos"
 
 export const useTokenDelegationSupported = (tokenAddress: string | undefined) => {
   const { tezos, isEtherlink } = useTezos()
 
-  const { data, ...rest } = useQuery<boolean, Error>(
-    ["delegationSupported", tokenAddress],
-    async () => {
+  const { data, ...rest } = useQuery<boolean, Error>({
+    queryKey: ["delegationSupported", tokenAddress],
+    queryFn: async () => {
       let tokenDelegationSupported = false
       if (tokenAddress) {
         tokenDelegationSupported = await isTokenDelegationSupported(tezos, tokenAddress)
       }
       return tokenDelegationSupported
     },
-    {
-      // Only run this Tezos-specific check on Tezos networks.
-      enabled: !!tokenAddress && !isEtherlink
-    }
-  )
+    // Only run this Tezos-specific check on Tezos networks.
+    enabled: !!tokenAddress && !isEtherlink
+  })
 
   return {
     data,

--- a/src/services/contracts/token/hooks/useTokenVoteWeight.ts
+++ b/src/services/contracts/token/hooks/useTokenVoteWeight.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { getTokenVoteWeight } from "services/bakingBad/delegations"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getCurrentBlock } from "services/utils/utils"
@@ -13,18 +13,16 @@ export const useTokenVoteWeight = (tokenAddress: string | undefined, level?: str
   const { network, account, etherlink } = useTezos()
   const tezosOrEthAccount = account || etherlink?.account?.address
 
-  const { data, ...rest } = useQuery<Result | undefined, Error>(
-    ["userTokenVoteWeight", tokenAddress, level],
-    async () => {
+  const { data, ...rest } = useQuery<Result | undefined, Error>({
+    queryKey: ["userTokenVoteWeight", tokenAddress, level],
+    queryFn: async () => {
       const blockLevel = level ? level : await getCurrentBlock(network)
       if (tokenAddress && blockLevel) {
         return await getTokenVoteWeight(tokenAddress, tezosOrEthAccount, network, blockLevel)
       }
     },
-    {
-      enabled: !!tokenAddress && !!tezosOrEthAccount
-    }
-  )
+    enabled: !!tokenAddress && !!tezosOrEthAccount
+  })
 
   return {
     data,

--- a/src/services/contracts/token/hooks/useUserTokenBalance.ts
+++ b/src/services/contracts/token/hooks/useUserTokenBalance.ts
@@ -1,19 +1,17 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { getUserTokenBalance } from "services/bakingBad/tokenBalances"
 import { useTezos } from "services/beacon/hooks/useTezos"
 
 export const useUserTokenBalance = (tokenAddress: string | undefined) => {
   const { network, account } = useTezos()
 
-  const { data, ...rest } = useQuery<string, Error>(
-    ["userTokenBalance", tokenAddress],
-    async () => {
+  const { data, ...rest } = useQuery<string, Error>({
+    queryKey: ["userTokenBalance", tokenAddress],
+    queryFn: async () => {
       return await getUserTokenBalance(account, network, tokenAddress)
     },
-    {
-      enabled: !!tokenAddress
-    }
-  )
+    enabled: !!tokenAddress
+  })
 
   return {
     data,

--- a/src/services/services/dao/hooks/useAllDAOs.ts
+++ b/src/services/services/dao/hooks/useAllDAOs.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery, keepPreviousData } from "@tanstack/react-query"
 import { Network } from "services/beacon"
 import { getDAOs } from "services/services/dao/services"
 import { getLiteDAOs } from "../../lite/lite-services"
@@ -16,7 +16,7 @@ export const useAllDAOs = (network: Network) => {
 
   // Always derive Etherlink DAOs from live context state so they react to
   // network changes and Firestore updates without being captured by a
-  // react-query fetcher closure.
+  // TanStack Query fetcher closure.
   const evmDaos =
     etherinkDaos?.map((dao: any) => ({
       ...dao,
@@ -38,10 +38,10 @@ export const useAllDAOs = (network: Network) => {
       underlyingToken: dao.underlyingToken
     })) || []
 
-  // Tezos sources via react-query. Keep hook order stable across network switches.
-  const queryData = useQuery(
-    ["daos", network],
-    async () => {
+  // Tezos sources via TanStack Query. Keep hook order stable across network switches.
+  const queryData = useQuery({
+    queryKey: ["daos", network],
+    queryFn: async () => {
       const isEtherlinkNetwork = String(network).includes("etherlink")
 
       let homebase_daos = [] as any[]
@@ -72,11 +72,9 @@ export const useAllDAOs = (network: Network) => {
 
       return [...homebase_daos, ...dedupedLiteDaos]
     },
-    {
-      // Always create the hook; let the fetcher short-circuit for Etherlink networks.
-      keepPreviousData: true
-    }
-  )
+    // Always create the hook; let the fetcher short-circuit for Etherlink networks.
+    placeholderData: keepPreviousData
+  })
 
   // Compose final list based on network.
   const isEtherlink = String(network).includes("etherlink")

--- a/src/services/services/dao/hooks/useDAO.ts
+++ b/src/services/services/dao/hooks/useDAO.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js"
 import { useState, useContext, useEffect, useMemo } from "react"
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { TZKTSubscriptionsContext } from "services/bakingBad/context/TZKTSubscriptions"
 import { getTokenMetadata } from "services/bakingBad/tokenBalances"
 import { Network } from "services/beacon"
@@ -28,9 +28,9 @@ export const useDAO = (address: string) => {
     state: { block }
   } = useContext(TZKTSubscriptionsContext)
 
-  const { data, ...rest } = useQuery(
-    ["dao", address],
-    async () => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["dao", address],
+    queryFn: async () => {
       const [response, liteDAO] = await Promise.all([getDAO(address as string), fetchLiteData(address, network)])
 
       console.log("useDAO.ts", { response, liteDAO })
@@ -109,12 +109,10 @@ export const useDAO = (address: string) => {
           throw new Error(`DAO with address '${dao.address}' has an unrecognized type '${dao.dao_type.name}'`)
       }
     },
-    {
-      enabled: !!address && !network?.startsWith("etherlink"),
-      refetchInterval: 30000,
-      refetchOnWindowFocus: false
-    }
-  )
+    enabled: !!address && !network?.startsWith("etherlink"),
+    refetchInterval: 30000,
+    refetchOnWindowFocus: false
+  })
 
   useEffect(() => {
     ;(async () => {

--- a/src/services/services/dao/hooks/useProposal.ts
+++ b/src/services/services/dao/hooks/useProposal.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { BaseDAO } from "services/contracts/baseDAO"
 import { LambdaProposal } from "../mappers/proposal/types"
 import { getProposal } from "../services"
@@ -7,9 +7,9 @@ import { useDAO } from "./useDAO"
 export const useProposal = (contractAddress: string, proposalKey: string) => {
   const { data: dao, isLoading, error, cycleInfo } = useDAO(contractAddress)
 
-  const queryResults = useQuery(
-    ["proposal", contractAddress, proposalKey],
-    async () => {
+  const queryResults = useQuery({
+    queryKey: ["proposal", contractAddress, proposalKey],
+    queryFn: async () => {
       const response = await getProposal(contractAddress as string, proposalKey)
       const proposal = response.daos[0].proposals[0]
 
@@ -20,11 +20,9 @@ export const useProposal = (contractAddress: string, proposalKey: string) => {
           throw new Error(`DAO with address '${dao?.data.address}' has an unrecognized type '${dao?.data.type}'`)
       }
     },
-    {
-      refetchInterval: 30000,
-      enabled: !!dao && !!cycleInfo
-    }
-  )
+    refetchInterval: 30000,
+    enabled: !!dao && !!cycleInfo
+  })
 
   return {
     data: queryResults.data,

--- a/src/services/services/dao/hooks/useProposals.ts
+++ b/src/services/services/dao/hooks/useProposals.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { BaseDAO, CycleInfo } from "services/contracts/baseDAO"
 import { getProposals } from "services/services/dao/services"
 import { ProposalStatus } from "services/services/dao/mappers/proposal/types"
@@ -10,9 +10,9 @@ export const useProposals = (contractAddress: string, status?: ProposalStatus) =
   const [proposalData, setProposalData] = useState<any[]>([])
   const { data: daoData, isLoading: isLoadingDAO, error, cycleInfo } = useDAO(contractAddress)
 
-  const queryResults = useQuery(
-    ["proposals", contractAddress, status],
-    async () => {
+  const queryResults = useQuery({
+    queryKey: ["proposals", contractAddress, status],
+    queryFn: async () => {
       const dao = daoData as BaseDAO
       const proposals = await getProposals(dao)
 
@@ -24,11 +24,9 @@ export const useProposals = (contractAddress: string, status?: ProposalStatus) =
         proposalData => proposalData.getStatus((cycleInfo as CycleInfo).currentLevel).status === status
       )
     },
-    {
-      refetchInterval: 30000,
-      enabled: !!daoData && !!cycleInfo
-    }
-  )
+    refetchInterval: 30000,
+    enabled: !!daoData && !!cycleInfo
+  })
 
   useEffect(() => {
     if (queryResults.data) {

--- a/src/services/tzprofiles/hooks/useProfileClaim.tsx
+++ b/src/services/tzprofiles/hooks/useProfileClaim.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useTezos } from "services/beacon/hooks/useTezos"
 import { getProfileClaim } from "../claims"
 import { Claim } from "../claims/types"
@@ -9,15 +9,13 @@ export const useProfileClaim = (tzAddress: string) => {
   const isTezosNetwork = !!network && (network.includes("tezos") || network === "mainnet" || network === "shadownet")
   const isTezosAddress = typeof tzAddress === "string" && tzAddress.startsWith("tz")
 
-  const result = useQuery<Claim, Error>(
-    ["tzProfile_profile_claim", tzAddress, network],
-    () => getProfileClaim(tzAddress, network),
-    {
-      enabled: isTezosNetwork && isTezosAddress,
-      cacheTime: Infinity,
-      refetchOnWindowFocus: false
-    }
-  )
+  const result = useQuery<Claim, Error>({
+    queryKey: ["tzProfile_profile_claim", tzAddress, network],
+    queryFn: () => getProfileClaim(tzAddress, network),
+    enabled: isTezosNetwork && isTezosAddress,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false
+  })
 
   return result
 }

--- a/src/services/wagmi/etherlink/hooks/useRegistry.ts
+++ b/src/services/wagmi/etherlink/hooks/useRegistry.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query"
+import { useQuery } from "@tanstack/react-query"
 import { ethers } from "ethers"
 import { registryContractABI } from "modules/etherlink/utils"
 
@@ -8,9 +8,9 @@ export interface RegistryEntry {
 }
 
 export const useRegistry = (provider: any, registryAddress: string | undefined, network: string) => {
-  return useQuery<RegistryEntry[], Error>(
-    ["registry", network, registryAddress],
-    async () => {
+  return useQuery<RegistryEntry[], Error>({
+    queryKey: ["registry", network, registryAddress],
+    queryFn: async () => {
       if (!provider || !registryAddress || !network) {
         throw new Error("Missing required parameters")
       }
@@ -46,12 +46,10 @@ export const useRegistry = (provider: any, registryAddress: string | undefined, 
         throw error
       }
     },
-    {
-      enabled: !!provider && !!registryAddress && !!network && ethers.isAddress(registryAddress || ""),
-      staleTime: 5 * 60 * 1000,
-      cacheTime: 10 * 60 * 1000,
-      retry: 2,
-      retryDelay: 1000
-    }
-  )
+    enabled: !!provider && !!registryAddress && !!network && ethers.isAddress(registryAddress || ""),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 2,
+    retryDelay: 1000
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1109,7 +1109,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/runtime@7.28.6", "@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.8", "@babel/runtime@^7.23.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+"@babel/runtime@7.28.6", "@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.19.4", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
@@ -6451,11 +6451,6 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-big-integer@^1.6.16:
-  version "1.6.52"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
-  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -6599,20 +6594,6 @@ braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-broadcast-channel@^3.4.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
-  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    detect-node "^2.1.0"
-    js-sha3 "0.8.0"
-    microseconds "0.2.0"
-    nano-time "1.0.0"
-    oblivious-set "1.0.0"
-    rimraf "3.0.2"
-    unload "2.2.0"
 
 broadcast-channel@^7.3.0:
   version "7.3.0"
@@ -8009,7 +7990,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4, detect-node@^2.1.0:
+detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -11953,11 +11934,6 @@ jiti@^1.21.7:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -12593,14 +12569,6 @@ markdown-table@^3.0.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.4.tgz#fe44d6d410ff9d6f2ea1797a3f60aa4d2b631c2a"
   integrity sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==
 
-match-sorter@^6.0.2:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.4.0.tgz#ae9c166cb3c9efd337690b3160c0e28cb8377c13"
-  integrity sha512-d4664ahzdL1QTTvmK1iI0JsrxWeJ6gn33qkYtnPg3mcn+naBLtXSgSPOe+X2vUgtgGwaAk3eiaj7gwKjjMAq+Q==
-  dependencies:
-    "@babel/runtime" "^7.23.8"
-    remove-accents "0.5.0"
-
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
@@ -13121,11 +13089,6 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-microseconds@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
-  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
-
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -13307,13 +13270,6 @@ mz@^2.7.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
-
-nano-time@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
-  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
-  dependencies:
-    big-integer "^1.6.16"
 
 nanoclone@^0.2.1:
   version "0.2.1"
@@ -13622,11 +13578,6 @@ object.values@^1.1.0, object.values@^1.1.6, object.values@^1.2.1:
     call-bound "^1.0.3"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
-
-oblivious-set@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
-  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 oblivious-set@2.0.0:
   version "2.0.0"
@@ -15244,15 +15195,6 @@ react-property@2.0.2:
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.2.tgz#d5ac9e244cef564880a610bc8d868bd6f60fdda6"
   integrity sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==
 
-react-query@^3.13.0:
-  version "3.39.3"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
-  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    broadcast-channel "^3.4.1"
-    match-sorter "^6.0.2"
-
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -15628,11 +15570,6 @@ remark-rehype@^10.0.0:
     mdast-util-to-hast "^12.1.0"
     unified "^10.0.0"
 
-remove-accents@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.5.0.tgz#77991f37ba212afba162e375b627631315bed687"
-  integrity sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -15783,7 +15720,7 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -17651,14 +17588,6 @@ universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
-
-unload@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
-  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    detect-node "^2.0.4"
 
 unload@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
## Summary

Removes the legacy **`react-query` v3** package (unmaintained), consolidating on **`@tanstack/react-query` v5** — which was already a dependency, used by the wagmi provider. A prior migration attempt had been started and abandoned (a commented-out TanStack provider in `App.tsx`); this completes it.

Net: **45 files** migrated, `react-query` removed from the dependency tree (-471/+322 lines, mostly the lockfile shrinking).

## Provider strategy (lowest-risk)

`App.tsx` keeps its configured `QueryClient` (with the project's `defaultOptions`) but now imports it from `@tanstack/react-query`. The wagmi `Web3Provider` already wraps the whole app with its own TanStack v5 client higher in the tree, so both clients are valid v5 and every hook resolves to App's nearest provider — `defaultOptions` preserved exactly. Unifying to a single client is deferred (it would change wagmi's internal query behavior, risking wallet flows).

## Changes

- **26 `useQuery`** call sites: positional `(key, fn, opts)` → object `{ queryKey, queryFn, ...opts }`
- **19 `useMutation`** call sites: positional `(fn, opts)` → object `{ mutationFn, ...opts }`
- `cacheTime` → `gcTime` (App.tsx + 4 hooks)
- `keepPreviousData: true` → `placeholderData: keepPreviousData` (`useAllDAOs`)
- **`useEvmProposalOps`**: 8 positional `invalidateQueries(["k"])` → `invalidateQueries({ queryKey: ["k"] })` — this is a *silent* runtime break in v5 (positional args are ignored), so it's the highest-value fix to verify
- All query keys were already arrays (v5-compatible); no `useInfiniteQuery`; `onSuccess` on mutations and `resetQueries()` no-arg are unchanged in v5

## Test plan

- [x] `yarn install` — `react-query` gone from tree
- [x] `npx tsc --noEmit` — green
- [x] `yarn build` — green
- [x] `yarn lint:check` — green
- [x] `yarn test:unit` — same 2 pre-existing jsdom-env failures, no new regressions
- [x] Deploy-preview smoke: DAO list + Tezos↔Etherlink network switch (`useAllDAOs` placeholderData), proposal auto-refetch (`useProposals`), voting (`useVote`), treasury/balances, lite polls, **Etherlink proposal create/execute → confirm member/proposal lists refresh** (validates the `invalidateQueries` fix), wallet connect/disconnect