### PR TITLE
fix: replace deprecated mainnet RPC endpoint with tcinfra

### DIFF
--- a/src/services/beacon/utils.ts
+++ b/src/services/beacon/utils.ts
@@ -8,7 +8,7 @@ import { EnvKey, getEnv } from "services/config"
 export type Network = "mainnet" | "shadownet" | "etherlink_shadownet" | "etherlink_mainnet"
 
 export const rpcNodes: Record<Network, string> = {
-  mainnet: getEnv(EnvKey.REACT_APP_RPC_NETWORK_MAINNET) || "https://mainnet.api.tez.ie",
+  mainnet: getEnv(EnvKey.REACT_APP_RPC_NETWORK_MAINNET) || "https://tcinfra.net/rpc/tezos/mainnet",
   shadownet: getEnv(EnvKey.REACT_APP_RPC_NETWORK_SHADOWNET) || "https://rpc.shadownet.teztnets.com",
   etherlink_shadownet: "https://node.shadownet.etherlink.com",
   etherlink_mainnet: "https://node.mainnet.etherlink.com"


### PR DESCRIPTION
## Problem
The default Tezos **mainnet** RPC (`https://mainnet.api.tez.ie`) was deprecated. Treasury balances stopped loading, and any other view that reads mainnet RPC is affected.

No `REACT_APP_RPC_NETWORK_MAINNET` override exists in the shipped env, so this dead endpoint is what production actually uses.

## Fix
Point the mainnet default at `https://tcinfra.net/rpc/tezos/mainnet` in `src/services/beacon/utils.ts`.

`rpcNodes.mainnet` is the single source of truth — consumed by `createTezos`, the beacon wallet, the baking-bad network map, and the ACI endpoint — so this one change restores treasury balances and every other mainnet RPC read.

## Verification
New endpoint confirmed live (HTTP 200, current mainnet head):
```
GET https://tcinfra.net/rpc/tezos/mainnet/chains/main/blocks/head/header
-> {"chain_id":"NetXdQprcVkpaWU", "level":13940533, ...}
```

## Review on deploy preview
- Connect a mainnet wallet, open a DAO treasury — balances should render.
- Spot-check other mainnet reads (DAO list, proposals) still load.