### PR TITLE
fix: MUI v6 UI regressions & explorer tab layout cleanup

### DIFF
--- a/src/components/ui/DaoCreator.tsx
+++ b/src/components/ui/DaoCreator.tsx
@@ -142,13 +142,13 @@ export const CustomFormikTextField = withStyles({
     "& .MuiInputBase-root": {
       textWeight: 300
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/components/ui/InputText.tsx
+++ b/src/components/ui/InputText.tsx
@@ -26,13 +26,13 @@ const InputText = withStyles(theme => ({
         opacity: 1
       }
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none"
     }
   }

--- a/src/components/ui/StyledTextField.tsx
+++ b/src/components/ui/StyledTextField.tsx
@@ -18,7 +18,7 @@ export const StyledTextField = styled(TextField)({
   "& label.Mui-focused": {
     color: "#fff"
   },
-  "& .MuiInput-underline:after": {
+  "& .MuiInput-root:after": {
     borderBottomColor: "#fff"
   },
   "& .MuiOutlinedInput-root": {
@@ -36,7 +36,7 @@ export const StyledTextField = styled(TextField)({
   "& .MuiInputLabel-root": {
     color: "rgba(255, 255, 255, 0.7)"
   },
-  "& .MuiInput-underline:before": {
+  "& .MuiInput-root:before": {
     borderBottomColor: "#ccc"
   }
 })

--- a/src/modules/common/SmallButton.tsx
+++ b/src/modules/common/SmallButton.tsx
@@ -7,17 +7,19 @@ export const SmallButton = styled(Button)({
   "transition": ".15s ease-out",
   "textTransform": "capitalize",
   "borderRadius": 8,
-  "backgroundColor": "#81feb7 !important",
+  "backgroundColor": "#81feb7",
   "color": "#1c1f23",
   "padding": "8px 16px",
 
-  "&$disabled": {
-    boxShadow: "none"
+  "&.Mui-disabled": {
+    boxShadow: "none",
+    backgroundColor: "#474E55",
+    color: "#7d8c8b"
   },
 
   "&:hover": {
     boxShadow: "0px 0px 7px -2px rgba(0, 0, 0, 0.2)",
-    backgroundColor: "#62eda5 !important",
+    backgroundColor: "#62eda5",
     transition: ".15s ease-in"
   }
 })
@@ -29,19 +31,20 @@ export const SmallButtonDialog = styled(Button)({
   "transition": ".15s ease-out",
   "textTransform": "capitalize",
   "borderRadius": 8,
-  "backgroundColor": "#81feb7 !important",
+  "backgroundColor": "#81feb7",
   "color": "#1c1f23",
   "padding": "8px 16px",
 
-  "&$disabled": {
+  "&.Mui-disabled": {
     boxShadow: "none",
-    backgroundColor: "#474E55 !important",
+    backgroundColor: "#474E55",
+    color: "#7d8c8b",
     border: "none"
   },
 
   "&:hover": {
     boxShadow: "0px 0px 7px -2px rgba(0, 0, 0, 0.2)",
-    backgroundColor: "#62eda5 !important",
+    backgroundColor: "#62eda5",
     transition: ".15s ease-in"
   }
 })

--- a/src/modules/creator/token/ui/index.tsx
+++ b/src/modules/creator/token/ui/index.tsx
@@ -57,13 +57,13 @@ export const CustomFormikTextField = withStyles({
     "& .MuiInputBase-input": {
       textAlign: "initial"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/etherlink/components/proposalRenderers/FullValueFieldWithCopy.tsx
+++ b/src/modules/etherlink/components/proposalRenderers/FullValueFieldWithCopy.tsx
@@ -22,13 +22,13 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
     padding: 0,
     cursor: "pointer"
   },
-  "& .MuiInput-underline:before": {
+  "& .MuiInput-root:before": {
     borderBottom: "none"
   },
-  "& .MuiInput-underline:after": {
+  "& .MuiInput-root:after": {
     borderBottom: "none"
   },
-  "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+  "& .MuiInput-root:hover:not(.Mui-disabled):before": {
     borderBottom: "none"
   }
 }))

--- a/src/modules/etherlink/components/proposalRenderers/ShortenedValueField.tsx
+++ b/src/modules/etherlink/components/proposalRenderers/ShortenedValueField.tsx
@@ -22,13 +22,13 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
     padding: 0,
     cursor: "pointer"
   },
-  "& .MuiInput-underline:before": {
+  "& .MuiInput-root:before": {
     borderBottom: "none"
   },
-  "& .MuiInput-underline:after": {
+  "& .MuiInput-root:after": {
     borderBottom: "none"
   },
-  "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+  "& .MuiInput-root:hover:not(.Mui-disabled):before": {
     borderBottom: "none"
   }
 }))

--- a/src/modules/explorer/components/ArbitraryContractInteractionForm.tsx
+++ b/src/modules/explorer/components/ArbitraryContractInteractionForm.tsx
@@ -178,13 +178,13 @@ const CustomFormikTextField = withStyles({
     "& .MuiInputBase-input": {
       textAlign: "initial"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/explorer/components/FilterNFTDialog.tsx
+++ b/src/modules/explorer/components/FilterNFTDialog.tsx
@@ -45,19 +45,16 @@ const CustomTextField = withStyles({
     "& .MuiInputBase-root": {
       textWeight: 300
     },
-    "& .MuiInput-underline": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
-      borderBottom: "none !important"
-    },
-    "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+    "& .MuiInput-root:hover:not(.Mui-disabled):before": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/explorer/components/FiltersTokensDialog.tsx
+++ b/src/modules/explorer/components/FiltersTokensDialog.tsx
@@ -40,19 +40,16 @@ const CustomTextField = withStyles({
     "& .MuiInputBase-root": {
       textWeight: 300
     },
-    "& .MuiInput-underline": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
-      borderBottom: "none !important"
-    },
-    "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+    "& .MuiInput-root:hover:not(.Mui-disabled):before": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/explorer/components/FiltersTransactionsDialog.tsx
+++ b/src/modules/explorer/components/FiltersTransactionsDialog.tsx
@@ -46,19 +46,16 @@ const CustomTextField = withStyles({
     "& .MuiInputBase-root": {
       textWeight: 300
     },
-    "& .MuiInput-underline": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
-      borderBottom: "none !important"
-    },
-    "& .MuiInput-underline:hover:not(.Mui-disabled):before": {
+    "& .MuiInput-root:hover:not(.Mui-disabled):before": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/explorer/components/ProposalActionsDialog.tsx
+++ b/src/modules/explorer/components/ProposalActionsDialog.tsx
@@ -31,13 +31,14 @@ export type ProposalFormDefaultValues = RecursivePartial<Values>
 
 // TODO: Move this to a shared component
 const OptionContainer = styled(Grid)(({ theme }) => ({
-  "minHeight": 80,
+  "minHeight": 110,
+  "height": "100%",
+  "boxSizing": "border-box",
   "background": theme.palette.primary.main,
   "borderRadius": 8,
-  "padding": "35px 42px",
+  "padding": "28px 42px",
   "marginBottom": 16,
   "cursor": "pointer",
-  "height": 110,
   "&:hover:enabled": {
     background: theme.palette.secondary.dark,
     scale: 1.01,

--- a/src/modules/explorer/pages/DAOList/components/Searchbar.tsx
+++ b/src/modules/explorer/pages/DAOList/components/Searchbar.tsx
@@ -31,13 +31,13 @@ const StyledInput = withStyles((theme: Theme) => ({
         outline: "none"
       }
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottomColor: "transparent"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottomColor: "transparent"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottomColor: "transparent"
     }
   }

--- a/src/modules/explorer/pages/Proposals/index.tsx
+++ b/src/modules/explorer/pages/Proposals/index.tsx
@@ -10,7 +10,6 @@ import { ReactComponent as LinkInactive } from "assets/img/link_inactive.svg"
 import { ReactComponent as UnlinkActive } from "assets/img/unlink_active.svg"
 import { ReactComponent as UnlinkInactive } from "assets/img/unlink_inactive.svg"
 
-import { ContentContainer } from "../../components/ContentContainer"
 import { SmallButton } from "modules/common/SmallButton"
 import { ProposalActionsDialog } from "modules/explorer/components/ProposalActionsDialog"
 import { TabPanel } from "modules/explorer/components/TabPanel"
@@ -35,27 +34,6 @@ const FiltersContainer = styled(Grid)({
 const TabsContainer = styled(Grid)({
   borderRadius: 8,
   gap: 16
-})
-
-const HeroContainer = styled(ContentContainer)(({ theme }) => ({
-  background: "inherit !important",
-  paddingTop: 0,
-  padding: "0px",
-  display: "inline-flex",
-  alignItems: "center",
-  [theme.breakpoints.down("md")]: {
-    maxHeight: "fit-content"
-  }
-}))
-
-const TitleText = styled(Typography)({
-  fontSize: 36,
-  fontWeight: 500,
-  lineHeight: 0.9,
-
-  ["@media (max-width:1030px)"]: {
-    fontSize: 26
-  }
 })
 
 const StyledTab = styled(({ isSelected, ...other }: any) => <Button {...other} />)(
@@ -173,94 +151,69 @@ const TezosProposals = () => {
   return (
     <>
       <Grid container direction="column" style={{ gap: 42 }}>
-        <HeroContainer item xs={12}>
-          <Grid container justifyContent="space-between" alignItems="center">
-            <Grid item container direction="row">
-              <Grid
-                container
-                style={{ gap: 20 }}
-                alignItems={isMobileSmall ? "baseline" : "center"}
-                direction={isMobileSmall ? "column" : "row"}
-              >
-                <Grid item xs={isMobileSmall ? undefined : 4}>
-                  <TitleText color="textPrimary">Proposals</TitleText>
-                </Grid>
-                <Grid
-                  item
-                  container
-                  justifyContent="flex-end"
-                  style={{ gap: 15 }}
-                  direction={isMobileSmall ? "column" : "row"}
-                  xs={isMobileSmall ? undefined : true}
-                >
-                  <NotContainedButton
-                    color="secondary"
-                    onClick={onFlush}
-                    disabled={!executableProposals || !executableProposals.length}
-                  >
-                    <NewReleasesIcon style={{ marginRight: 8, fontSize: 20 }} />
-                    Execute
-                  </NotContainedButton>
-                  <NotContainedButton
-                    color="secondary"
-                    onClick={onDropAllExpired}
-                    disabled={!expiredProposals || !expiredProposals.length}
-                  >
-                    <DeleteIcon style={{ marginRight: 4, fontSize: 20 }} />
-                    Drop Expired
-                  </NotContainedButton>
-                  <SmallButton variant="contained" color="secondary" onClick={() => setOpenDialog(true)}>
-                    New Proposal
-                  </SmallButton>
-                  {/* <Grid>
-                    <Tooltip placement="bottom" title="Execute all passed proposals and drop all expired or rejected">
-                      <InfoIcon style={{ height: 16 }} color="secondary" />
-                    </Tooltip>
-                  </Grid> */}
-
-                  {/* <Grid>
-
-                    <Tooltip placement="bottom" title="Drop all expired proposals">
-                      <InfoIcon style={{ height: 16 }} color="secondary" />
-                    </Tooltip>
-                  </Grid> */}
-                </Grid>
-                <Grid container direction="row">
-                  <Typography variant="body1" style={{ color: theme.palette.primary.light }}>
-                    Create, view, and vote on On-Chain and Off-Chain proposals
-                  </Typography>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-        </HeroContainer>
-
         <TabsBox item>
-          <Grid item>
-            <TabsContainer container>
-              <Grid item>
-                <StyledTab
-                  startIcon={selectedTab === 0 ? <LinkActive /> : <LinkInactive />}
-                  variant="contained"
-                  disableElevation={true}
-                  onClick={() => handleChangeTab(0)}
-                  isSelected={selectedTab === 0}
-                >
-                  On-Chain
-                </StyledTab>
-              </Grid>
-              <Grid item>
-                <StyledTab
-                  startIcon={selectedTab === 1 ? <UnlinkActive /> : <UnlinkInactive />}
-                  disableElevation={true}
-                  variant="contained"
-                  onClick={() => handleChangeTab(1)}
-                  isSelected={selectedTab === 1}
-                >
-                  Off-Chain
-                </StyledTab>
-              </Grid>
-            </TabsContainer>
+          <Grid
+            container
+            justifyContent="space-between"
+            alignItems="center"
+            direction={isMobileSmall ? "column" : "row"}
+            style={{ gap: 15 }}
+          >
+            <Grid item>
+              <TabsContainer container>
+                <Grid item>
+                  <StyledTab
+                    startIcon={selectedTab === 0 ? <LinkActive /> : <LinkInactive />}
+                    variant="contained"
+                    disableElevation={true}
+                    onClick={() => handleChangeTab(0)}
+                    isSelected={selectedTab === 0}
+                  >
+                    On-Chain
+                  </StyledTab>
+                </Grid>
+                <Grid item>
+                  <StyledTab
+                    startIcon={selectedTab === 1 ? <UnlinkActive /> : <UnlinkInactive />}
+                    disableElevation={true}
+                    variant="contained"
+                    onClick={() => handleChangeTab(1)}
+                    isSelected={selectedTab === 1}
+                  >
+                    Off-Chain
+                  </StyledTab>
+                </Grid>
+              </TabsContainer>
+            </Grid>
+            <Grid
+              item
+              container
+              justifyContent="flex-end"
+              alignItems="center"
+              style={{ gap: 15 }}
+              direction={isMobileSmall ? "column" : "row"}
+              xs={isMobileSmall ? undefined : true}
+            >
+              <NotContainedButton
+                color="secondary"
+                onClick={onFlush}
+                disabled={!executableProposals || !executableProposals.length}
+              >
+                <NewReleasesIcon style={{ marginRight: 8, fontSize: 20 }} />
+                Execute
+              </NotContainedButton>
+              <NotContainedButton
+                color="secondary"
+                onClick={onDropAllExpired}
+                disabled={!expiredProposals || !expiredProposals.length}
+              >
+                <DeleteIcon style={{ marginRight: 4, fontSize: 20 }} />
+                Drop Expired
+              </NotContainedButton>
+              <SmallButton variant="contained" color="secondary" onClick={() => setOpenDialog(true)}>
+                New Proposal
+              </SmallButton>
+            </Grid>
           </Grid>
 
           <FiltersContainer

--- a/src/modules/explorer/pages/Registry/components/RegistryTable.tsx
+++ b/src/modules/explorer/pages/Registry/components/RegistryTable.tsx
@@ -16,6 +16,7 @@ import dayjs from "dayjs"
 import { RegistryItemDialog } from "modules/explorer/components/ItemDialog"
 import { OverflowCell } from "./OverflowCell"
 import { ContentContainer } from "modules/explorer/components/ContentContainer"
+import Inventory2OutlinedIcon from "@mui/icons-material/Inventory2Outlined"
 
 const localizedFormat = require("dayjs/plugin/localizedFormat")
 dayjs.extend(localizedFormat)
@@ -171,7 +172,24 @@ export const RegistryTable: React.FC<{ data: RowData[] }> = ({ data: propsData }
   return (
     <>
       <TableContainer item>
-        {isSmall ? <MobileRegistryTable data={data} /> : <DesktopRegistryTable data={data} />}
+        {data.length === 0 ? (
+          <Grid
+            container
+            direction="column"
+            alignItems="center"
+            justifyContent="center"
+            style={{ padding: "72px 0", gap: 16, opacity: 0.4 }}
+          >
+            <Inventory2OutlinedIcon style={{ fontSize: 64 }} color="inherit" />
+            <Typography variant="h5" color="textPrimary" align="center">
+              No items in registry yet…
+            </Typography>
+          </Grid>
+        ) : isSmall ? (
+          <MobileRegistryTable data={data} />
+        ) : (
+          <DesktopRegistryTable data={data} />
+        )}
       </TableContainer>
 
       <RegistryItemDialog

--- a/src/modules/explorer/pages/Registry/components/UpdatesTable.tsx
+++ b/src/modules/explorer/pages/Registry/components/UpdatesTable.tsx
@@ -137,6 +137,10 @@ export const UpdatesTable: React.FC<{ data: RowData[] }> = ({ data }) => {
   const theme = useTheme()
   const isSmall = useMediaQuery(theme.breakpoints.down("lg"))
 
+  if (!data || data.length === 0) {
+    return null
+  }
+
   return (
     <TableContainer item>
       {isSmall ? <MobileUpdatesTable data={data} /> : <DesktopUpdatesTable data={data} />}

--- a/src/modules/explorer/pages/Registry/index.tsx
+++ b/src/modules/explorer/pages/Registry/index.tsx
@@ -1,5 +1,4 @@
-import { Button, Grid, Tooltip, useMediaQuery, useTheme } from "@mui/material"
-import { CopyAddress } from "modules/common/CopyAddress"
+import { Grid, Tooltip } from "@mui/material"
 import { ProposalFormContainer, ProposalFormDefaultValues } from "modules/explorer/components/ProposalForm"
 
 import React, { useMemo, useState } from "react"
@@ -7,18 +6,14 @@ import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useProposals } from "services/services/dao/hooks/useProposals"
 import { LambdaProposal } from "services/services/dao/mappers/proposal/types"
 import { Hero } from "../../components/Hero"
-import { HeroTitle } from "../../components/HeroTitle"
 import { useDAOID } from "../DAO/router"
 import { RegistryTable } from "./components/RegistryTable"
 import { UpdatesTable } from "./components/UpdatesTable"
 import { useIsProposalButtonDisabled } from "../../../../services/contracts/baseDAO/hooks/useCycleInfo"
-import { InfoIcon } from "../../components/styled/InfoIcon"
-import { MainButton } from "../../../common/MainButton"
+import { SmallButton } from "../../../common/SmallButton"
 import { LambdaDAO } from "services/contracts/baseDAO/lambdaDAO"
 
 export const Registry: React.FC = () => {
-  const theme = useTheme()
-  const isMobileSmall = useMediaQuery(theme.breakpoints.down("lg"))
   const daoId = useDAOID()
   const { data: dao } = useDAO(daoId)
   const [updateRegistryOpen, setUpdateRegistryOpen] = useState(false)
@@ -81,33 +76,21 @@ export const Registry: React.FC = () => {
 
   return (
     <>
-      <Grid container direction="column" style={{ gap: 42 }}>
+      <Grid container direction="column" style={{ gap: 42, minHeight: "calc(100vh - 40px)" }}>
         <Hero>
-          <Grid item>
-            <HeroTitle>Registry</HeroTitle>
-            {dao && (
-              <CopyAddress
-                address={dao.data.address}
-                justifyContent={isMobileSmall ? "center" : "flex-start"}
-                typographyProps={{
-                  variant: "subtitle2"
-                }}
-              />
-            )}
-          </Grid>
-          <Grid item>
-            <MainButton
-              variant="contained"
-              color="secondary"
-              onClick={() => setUpdateRegistryOpen(true)}
-              disabled={shouldDisable}
-            >
-              New Item
-            </MainButton>
-            {shouldDisable && (
+          <Grid item xs container justifyContent="flex-end">
+            {shouldDisable ? (
               <Tooltip placement="bottom" title="Not on proposal creation period">
-                <InfoIcon color="secondary" />
+                <span>
+                  <SmallButton variant="contained" color="secondary" disabled>
+                    Edit/Add Item
+                  </SmallButton>
+                </span>
               </Tooltip>
+            ) : (
+              <SmallButton variant="contained" color="secondary" onClick={() => setUpdateRegistryOpen(true)}>
+                Edit/Add Item
+              </SmallButton>
             )}
           </Grid>
         </Hero>

--- a/src/modules/explorer/pages/Treasury/index.tsx
+++ b/src/modules/explorer/pages/Treasury/index.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo, useState } from "react"
 import { Button, Grid, Theme, Tooltip, Typography, useMediaQuery, useTheme } from "@mui/material"
-import { useDAO } from "services/services/dao/hooks/useDAO"
 import { useDAOID } from "../DAO/router"
 import { BalancesTable } from "./components/BalancesTable"
 import { TransfersTable } from "./components/TransfersTable"
 import { TransferWithBN, useTransfers } from "../../../../services/contracts/baseDAO/hooks/useTransfers"
-import { InfoIcon } from "../../components/styled/InfoIcon"
 import { useIsProposalButtonDisabled } from "../../../../services/contracts/baseDAO/hooks/useCycleInfo"
 import { styled } from "@mui/material"
 import { TabPanel } from "modules/explorer/components/TabPanel"
@@ -14,8 +12,6 @@ import TollIcon from "@mui/icons-material/Toll"
 import PaletteIcon from "@mui/icons-material/Palette"
 import ReceiptIcon from "@mui/icons-material/Receipt"
 import { SmallButton } from "modules/common/SmallButton"
-import { ContentContainer } from "modules/explorer/components/ContentContainer"
-import { CopyButton } from "modules/common/CopyButton"
 import { TreasuryDialog } from "./components/TreasuryDialog"
 import { SearchInput } from "../DAOList/components/Searchbar"
 import FilterAltIcon from "@mui/icons-material/FilterAlt"
@@ -44,16 +40,6 @@ const TabsBox = styled(Grid)(({ theme }) => ({
 const TabsContainer = styled(Grid)({
   borderRadius: 8,
   gap: 16
-})
-
-const TitleText = styled(Typography)({
-  fontSize: 36,
-  fontWeight: 500,
-  lineHeight: 0.9,
-
-  ["@media (max-width:1030px)"]: {
-    fontSize: 26
-  }
 })
 
 export interface TransactionsFilters {
@@ -92,22 +78,10 @@ const StyledTab = styled(({ isSelected, ...other }: any) => <Button {...other} /
   })
 )
 
-const HeroContainer = styled(ContentContainer)(({ theme }) => ({
-  background: "inherit !important",
-  paddingTop: 0,
-  padding: "0px",
-  display: "inline-flex",
-  alignItems: "center",
-  [theme.breakpoints.down("md")]: {
-    maxHeight: "fit-content"
-  }
-}))
-
 export const Treasury: React.FC = () => {
   const theme = useTheme()
   const isMobileSmall = useMediaQuery(theme.breakpoints.down("lg"))
   const daoId = useDAOID()
-  const { data: dao } = useDAO(daoId)
   const [openTransfer, setOpenTransfer] = useState(false)
   const [selectedTab, setSelectedTab] = React.useState(0)
   const [searchText, setSearchText] = useState("")
@@ -176,115 +150,72 @@ export const Treasury: React.FC = () => {
   return (
     <>
       <Grid container direction="column" style={{ gap: 42 }}>
-        <HeroContainer item xs={12}>
-          <Grid container justifyContent="space-between" alignItems="center">
-            <Grid item container direction="row">
-              <Grid
-                container
-                style={{ gap: 20 }}
-                alignItems={isMobileSmall ? "baseline" : "center"}
-                direction={isMobileSmall ? "column" : "row"}
-              >
-                <Grid
-                  container
-                  direction="row"
-                  justifyContent="flex-start"
-                  alignItems="center"
-                  item
-                  xs={isMobileSmall ? undefined : 7}
-                >
-                  <Grid item xs={isMobileSmall ? 12 : 2}>
-                    <TitleText color="textPrimary">Treasury</TitleText>
-                  </Grid>
-                </Grid>
-                <Grid
-                  item
-                  container
-                  justifyContent="flex-end"
-                  alignItems="center"
-                  style={{ gap: 15 }}
-                  direction={isMobileSmall ? "row" : "row"}
-                  xs={isMobileSmall ? undefined : true}
-                >
-                  {dao && (
-                    <Grid
-                      item
-                      xs
-                      container
-                      justifyContent={"flex-end"}
-                      direction="row"
-                      style={isMobileSmall ? {} : { marginLeft: 30 }}
-                    >
-                      <CopyButton style={{ marginRight: 4 }} text={dao?.data.address} displayedText="Copy Address" />
-                    </Grid>
-                  )}
-                  <SmallButton
-                    variant="contained"
-                    color="secondary"
-                    onClick={() => setOpenTransfer(true)}
-                    disabled={shouldDisable}
-                  >
-                    New Transfer
-                  </SmallButton>
-                  {shouldDisable && (
-                    <Tooltip placement="bottom" title="Not on proposal creation period">
-                      <InfoIcon color="secondary" />
-                    </Tooltip>
-                  )}
-                </Grid>
-                <Grid container direction="row">
-                  <Typography variant="body1" style={{ color: theme.palette.primary.light }}>
-                    Transfer tokens and NFTs, and view balances and transaction history{" "}
-                  </Typography>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-        </HeroContainer>
-
         <TabsBox item>
-          <Grid item style={{ marginBottom: 32 }}>
-            <TabsContainer container>
-              <Grid item>
-                <StyledTab
-                  startIcon={
-                    <TollIcon style={{ color: "inherit" }} color={selectedTab === 0 ? "secondary" : "inherit"} />
-                  }
-                  variant="contained"
-                  disableElevation={true}
-                  onClick={() => handleChangeTab(0)}
-                  isSelected={selectedTab === 0}
-                >
-                  Tokens
-                </StyledTab>
-              </Grid>
-              <Grid item>
-                <StyledTab
-                  startIcon={
-                    <PaletteIcon style={{ color: "inherit" }} color={selectedTab === 1 ? "secondary" : "inherit"} />
-                  }
-                  disableElevation={true}
-                  variant="contained"
-                  onClick={() => handleChangeTab(1)}
-                  isSelected={selectedTab === 1}
-                >
-                  NFTs
-                </StyledTab>
-              </Grid>
-              <Grid item>
-                <StyledTab
-                  startIcon={
-                    <ReceiptIcon style={{ color: "inherit" }} color={selectedTab === 2 ? "secondary" : "inherit"} />
-                  }
-                  disableElevation={true}
-                  variant="contained"
-                  onClick={() => handleChangeTab(2)}
-                  isSelected={selectedTab === 2}
-                >
-                  Transactions
-                </StyledTab>
-              </Grid>
-            </TabsContainer>
+          <Grid
+            container
+            justifyContent="space-between"
+            alignItems="center"
+            direction={isMobileSmall ? "column" : "row"}
+            style={{ gap: 15, marginBottom: 32 }}
+          >
+            <Grid item>
+              <TabsContainer container>
+                <Grid item>
+                  <StyledTab
+                    startIcon={
+                      <TollIcon style={{ color: "inherit" }} color={selectedTab === 0 ? "secondary" : "inherit"} />
+                    }
+                    variant="contained"
+                    disableElevation={true}
+                    onClick={() => handleChangeTab(0)}
+                    isSelected={selectedTab === 0}
+                  >
+                    Tokens
+                  </StyledTab>
+                </Grid>
+                <Grid item>
+                  <StyledTab
+                    startIcon={
+                      <PaletteIcon style={{ color: "inherit" }} color={selectedTab === 1 ? "secondary" : "inherit"} />
+                    }
+                    disableElevation={true}
+                    variant="contained"
+                    onClick={() => handleChangeTab(1)}
+                    isSelected={selectedTab === 1}
+                  >
+                    NFTs
+                  </StyledTab>
+                </Grid>
+                <Grid item>
+                  <StyledTab
+                    startIcon={
+                      <ReceiptIcon style={{ color: "inherit" }} color={selectedTab === 2 ? "secondary" : "inherit"} />
+                    }
+                    disableElevation={true}
+                    variant="contained"
+                    onClick={() => handleChangeTab(2)}
+                    isSelected={selectedTab === 2}
+                  >
+                    Transactions
+                  </StyledTab>
+                </Grid>
+              </TabsContainer>
+            </Grid>
+            <Grid item>
+              {shouldDisable ? (
+                <Tooltip placement="bottom" title="Not on proposal creation period">
+                  <span>
+                    <SmallButton variant="contained" color="secondary" disabled>
+                      New Transfer
+                    </SmallButton>
+                  </span>
+                </Tooltip>
+              ) : (
+                <SmallButton variant="contained" color="secondary" onClick={() => setOpenTransfer(true)}>
+                  New Transfer
+                </SmallButton>
+              )}
+            </Grid>
           </Grid>
 
           <ItemGrid item>

--- a/src/modules/lite/creator/index.tsx
+++ b/src/modules/lite/creator/index.tsx
@@ -122,13 +122,13 @@ const CustomFormikTextField = withStyles({
     "& .MuiInputBase-input": {
       textAlign: "initial"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/lite/explorer/components/Choices.tsx
+++ b/src/modules/lite/explorer/components/Choices.tsx
@@ -94,13 +94,13 @@ const CustomFormikChoiceTextField = withStyles({
     "& .MuiInputBase-input": {
       textAlign: "initial"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/modules/lite/explorer/pages/CreateProposal/index.tsx
+++ b/src/modules/lite/explorer/pages/CreateProposal/index.tsx
@@ -76,13 +76,13 @@ const CustomFormikTextField = withStyles({
       fontSize: 18,
       background: "#2f3438"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:not(.Mui-disabled):before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }
@@ -101,13 +101,13 @@ const CustomFormikTimeTextField = withStyles({
       fontSize: 18,
       background: "#2f3438"
     },
-    "& .MuiInput-underline:before": {
+    "& .MuiInput-root:before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:hover:before": {
+    "& .MuiInput-root:hover:not(.Mui-disabled):before": {
       borderBottom: "none !important"
     },
-    "& .MuiInput-underline:after": {
+    "& .MuiInput-root:after": {
       borderBottom: "none !important"
     }
   }

--- a/src/services/services/dao/hooks/useDAO.ts
+++ b/src/services/services/dao/hooks/useDAO.ts
@@ -31,7 +31,13 @@ export const useDAO = (address: string) => {
   const { data, ...rest } = useQuery({
     queryKey: ["dao", address],
     queryFn: async () => {
-      const [response, liteDAO] = await Promise.all([getDAO(address as string), fetchLiteData(address, network)])
+      // Lite data is supplementary to an on-chain DAO. A lite-backend outage
+      // (or a DAO that has no lite community) must not prevent the on-chain DAO
+      // from loading, so treat any lite failure as "no lite data".
+      const [response, liteDAO] = await Promise.all([
+        getDAO(address as string),
+        fetchLiteData(address, network).catch(() => undefined)
+      ])
 
       console.log("useDAO.ts", { response, liteDAO })
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -7,6 +7,12 @@ export const theme = createTheme(
     props: {
       MuiButtonBase: {
         disableRipple: true
+      },
+      // MUI v5+ changed the default TextField variant from "standard" to "outlined".
+      // This app's fields and theme overrides are all written for the standard
+      // (underline) variant, so restore it globally to avoid the stray outlined border.
+      MuiTextField: {
+        variant: "standard"
       }
     },
     palette: {


### PR DESCRIPTION
## Summary
Fixes visual regressions introduced by the @material-ui v4 → @mui v6 migration (#953), plus a set of explorer tab layout improvements and one data-resilience fix. All changes are on the **L1 / Tezos** explorer surfaces; the Etherlink path is untouched.

## MUI v6 regressions
- **TextField outlined border** — v5+ changed the default `TextField` variant from `standard` to `outlined`, so every field the app styles as a filled input gained a stray notched-outline `<fieldset>`. Restored `variant: "standard"` globally via the theme.
- **Dead v4 CSS selectors** that silently stopped matching in v6:
  - `.MuiInput-underline` → `.MuiInput-root` (the underline pseudo-elements moved onto the root in v5) across all styled text fields — removes the phantom underline.
  - `&$disabled` → `&.Mui-disabled` on `SmallButton`/`SmallButtonDialog`, and dropped a `backgroundColor !important` that was defeating MUI's disabled greying. Disabled buttons now grey out (grey background + muted text) instead of green-with-unreadable-near-white text.
- **New Proposal modal** — option cards were fixed-height and clipped two-line descriptions; now `minHeight` + stretch so they grow to fit and stay row-aligned.

## Explorer tab cleanup (Proposals / Treasury / Registry)
- Removed the redundant in-content page titles and description subtitles (the selected tab already is the title).
- **Proposals**: moved *Execute / Drop Expired / New Proposal* onto the On-Chain/Off-Chain switch row (top right); removed the now-empty hero header.
- **Treasury**: moved *New Transfer* onto the Tokens/NFTs/Transactions switch row; removed *Copy Address* and the standalone info icon; the wrong-cycle tooltip now sits on the button itself.
- **Registry**: *New Item* → *Edit/Add Item* using the shared `SmallButton`; tooltip on the button; removed the address/copy header; added a faded empty state (icon + "No items in registry yet…"); the update-history header is hidden when empty; a min-height keeps the footer below the fold regardless of item count.

## Data resilience
- `useDAO` now catches a failure of the supplementary lite-backend fetch, so a lite outage no longer rejects the whole DAO query and mislabels an on-chain DAO as "being indexed."

## Review on deploy preview
- Open the *New Proposal* modal → cards fit their descriptions.
- Off-Chain Poll / creator / filter dialogs → text fields have no outer outline or stray underline.
- Treasury/Registry in a non-creation cycle → action buttons grey out with a hover tooltip, text readable.
- Proposals/Treasury/Registry → action buttons sit on the tab-switch row; no duplicate titles.
- A registry with no items → faded empty state, footer below the fold, no stray table headers.