### PR TITLE
fix: reproducible-build workflow was invalid YAML

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -43,15 +43,18 @@ jobs:
         run: |
           HASH="$(cat distribution/out/BUILDHASH)"
           cp distribution/out/BUILDHASH distribution/out/BUILDHASH.txt
+          {
+            echo "BUILDHASH: \`${HASH}\`"
+            echo ""
+            echo "Verify independently:"
+            echo '```'
+            echo "git clone https://github.com/${GITHUB_REPOSITORY} && cd homebase-app"
+            echo "distribution/verify.sh ${GITHUB_REF_NAME} ${HASH}"
+            echo '```'
+          } > "${RUNNER_TEMP}/release-notes.md"
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
-            --notes "BUILDHASH: \`${HASH}\`
-
-Verify independently:
-\`\`\`
-git clone https://github.com/${GITHUB_REPOSITORY} && cd homebase-app
-distribution/verify.sh ${GITHUB_REF_NAME} ${HASH}
-\`\`\`" \
+            --notes-file "${RUNNER_TEMP}/release-notes.md" \
             distribution/out/homebase-build.tar.gz \
             distribution/out/BUILDHASH.txt \
             distribution/out/BUILDMANIFEST


### PR DESCRIPTION
The multi-line release notes passed to `gh release create --notes` started at column 0 inside the `run: |` block, terminating the YAML block scalar and making the whole workflow file unparseable — every trigger since #959 merged failed in 0s with "workflow file issue", including the `v6.0.0` tag push.

Fix: build the notes with `echo` lines into `$RUNNER_TEMP/release-notes.md` and use `--notes-file`. Workflow YAML now validates.

After merge: re-push the `v6.0.0` tag to re-trigger the release pipeline.