### PR TITLE
feat: verify releases against the on-chain registry (verify.sh --registry)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF everywhere — a CRLF checkout on Windows breaks
+# them at runtime (trailing \r in comparisons and URLs), and that exact bug
+# once silenced production monitoring for months.
+*.sh text eol=lf

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -30,6 +30,10 @@ distribution/build.sh
 
 # Verify a release against its published hash (from the GitHub Release page)
 distribution/verify.sh v1.2.3 <expected-sha256>
+
+# Verify a release against the ON-CHAIN registry (trustless: commit + hash
+# are read from the release-registry contract, then rebuilt and compared)
+distribution/verify.sh --registry <mainnet|shadownet> <registry-address> <version-key>
 ```
 
 `BUILDHASH` is the sha256 over the sorted per-file sha256s of `build/`
@@ -42,6 +46,24 @@ Pushing a `v*` tag triggers `.github/workflows/reproducible-build.yml`,
 which builds, **rebuilds from scratch and fails unless both hashes match**,
 then publishes the artifact, `BUILDHASH.txt`, and the manifest on the
 GitHub Release.
+
+## On-chain release registry
+
+Releases are recorded in the Registry contract of a Homebase EVM DAO (the
+app's own audited governance stack — the release process dogfoods the
+product). Each approved release is a registry entry: key `vX.Y.Z`, value
+`{"commit":"<sha>","buildhash":"<sha256>","artifact":"<url>"}`. Entries only
+change through a governance proposal (propose → vote → timelock → execute),
+so "the official build" is a DAO decision, not a hosting-account setting.
+`verify.sh --registry` closes the loop: on-chain record → source commit →
+reproducible rebuild → hash comparison, with no trusted intermediary.
+
+Current registries:
+
+| Network | DAO | Registry | Status |
+|---|---|---|---|
+| Shadownet | `0xEeDCa7F405210cBCB4E63a67F18e974c821F4Ca1` ("Homebase Distribution (Rehearsal)") | `0x2A847c27663aB55aa36387c4Ce719789e3bc8cE9` | rehearsal, live |
+| Mainnet | — | — | planned |
 
 ## Boundaries (honest ones)
 

--- a/distribution/verify.sh
+++ b/distribution/verify.sh
@@ -1,23 +1,87 @@
 #!/usr/bin/env bash
 # Independently verify a Homebase release.
 #
-# Rebuilds the given git ref from source in the pinned environment and
-# compares the resulting fingerprint against an expected hash (e.g. the
-# BUILDHASH published on the GitHub Release, or — in later phases — the
-# hash recorded in the on-chain release registry).
+# Two modes:
 #
-# Usage:  distribution/verify.sh <git-ref> <expected-sha256>
+# 1) Against a hash you already trust (e.g. from the GitHub Release):
+#      distribution/verify.sh <git-ref> <expected-sha256>
+#
+# 2) Against the on-chain release registry (trustless — the expected hash
+#    and the source commit are read from an Etherlink registry contract
+#    governed by the Homebase Distribution DAO):
+#      distribution/verify.sh --registry <network> <registry-address> <version-key>
+#    e.g.
+#      distribution/verify.sh --registry shadownet 0x2A847c27663aB55aa36387c4Ce719789e3bc8cE9 v6.0.0-rc-rehearsal
+#
+#    <network> is mainnet | shadownet, or a full JSON-RPC URL.
+#    The registry value must be JSON: {"commit":"<sha>","buildhash":"<sha256>",...}
+#    The build is then made from that exact commit and compared to that hash,
+#    so a MATCH proves: on-chain record -> source -> bundle, end to end.
 #
 # Exit codes: 0 = MATCH (the source provably produces the published bundle)
 #             1 = MISMATCH (investigate: toolchain drift or tampering)
+#             2 = usage / lookup error
 set -euo pipefail
 
-if [ $# -ne 2 ]; then
+# getRegistryValue(string) on the Registry contract deployed with every
+# Homebase EVM DAO (trustless-contracts Registry.sol).
+REGISTRY_SELECTOR="0x2e9c247b"
+
+rpc_url_for() {
+  case "$1" in
+    mainnet)   echo "https://node.mainnet.etherlink.com" ;;
+    shadownet) echo "https://node.shadownet.etherlink.com" ;;
+    http*)     echo "$1" ;;
+    *)         echo "unknown network '$1' (use mainnet, shadownet, or a URL)" >&2; return 2 ;;
+  esac
+}
+
+read_registry() { # <rpc-url> <registry-address> <key>  -> prints value string
+  RPC_URL="$1" REG_ADDR="$2" REG_KEY="$3" SELECTOR="$REGISTRY_SELECTOR" python3 - <<'PYEOF'
+import json, os, sys, urllib.request
+
+rpc, addr, key, sel = (os.environ[v] for v in ("RPC_URL", "REG_ADDR", "REG_KEY", "SELECTOR"))
+kb = key.encode()
+padded = kb.hex().ljust(((len(kb) + 31) // 32) * 64, "0")
+data = sel + f"{32:064x}" + f"{len(kb):064x}" + padded
+req = {"jsonrpc": "2.0", "method": "eth_call",
+       "params": [{"to": addr, "data": data}, "latest"], "id": 1}
+resp = json.loads(urllib.request.urlopen(
+    urllib.request.Request(rpc, json.dumps(req).encode(),
+                           {"Content-Type": "application/json"}), timeout=30).read())
+if "error" in resp:
+    sys.exit(f"eth_call failed: {resp['error']}")
+raw = resp["result"][2:]
+if not raw:
+    sys.exit("empty eth_call result — wrong address or no code")
+length = int(raw[64:128], 16)
+value = bytes.fromhex(raw[128:128 + length * 2]).decode()
+if not value:
+    sys.exit("registry returned an empty value for this key")
+print(value)
+PYEOF
+}
+
+if [ "${1:-}" = "--registry" ]; then
+  if [ $# -ne 4 ]; then
+    echo "usage: $0 --registry <network|rpc-url> <registry-address> <version-key>" >&2
+    exit 2
+  fi
+  RPC="$(rpc_url_for "$2")"
+  echo "reading key '$4' from registry $3 ..."
+  VALUE="$(read_registry "$RPC" "$3" "$4")"
+  echo "on-chain record: $VALUE"
+  REF="$(echo "$VALUE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["commit"])')"
+  EXPECTED="$(echo "$VALUE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["buildhash"])')"
+  echo "commit:   $REF"
+elif [ $# -eq 2 ]; then
+  REF="$1"
+  EXPECTED="$2"
+else
   echo "usage: $0 <git-ref> <expected-sha256>" >&2
+  echo "       $0 --registry <network|rpc-url> <registry-address> <version-key>" >&2
   exit 2
 fi
-REF="$1"
-EXPECTED="$2"
 
 "$(dirname "$0")/build.sh" --no-cache "$REF"
 


### PR DESCRIPTION
Adds a second mode to `distribution/verify.sh`:

```
distribution/verify.sh --registry <mainnet|shadownet|rpc-url> <registry-address> <version-key>
```

It reads the release record (`{"commit", "buildhash", "artifact"}`) from the Registry contract of a Homebase EVM DAO via a raw `eth_call` (selector `0x2e9c247b` = `getRegistryValue(string)`; zero dependencies beyond python3), rebuilds that exact commit in the pinned environment, and compares fingerprints. A MATCH proves the chain-approved record, the source, and the bundle are one and the same — no trusted intermediary, not even the GitHub Release page.

Tested live against the shadownet rehearsal DAO's registry (`0x2A847c27663aB55aa36387c4Ce719789e3bc8cE9`, key `v6.0.0-rc-rehearsal`) — record reads back exactly as governance approved it earlier today. README documents the registry scheme and current deployments.

Part of the decentralized-distribution track: registry rehearsal ran end-to-end on shadownet today (deploy → propose → vote → queue → execute → readback) via the same factory the app uses; the DAO is visible in the shadownet explorer.