### PR TITLE
fix: surface ERC20Votes self-delegation before proposal creation

### DIFF
--- a/src/modules/etherlink/components/EvmDelegationPrompt.tsx
+++ b/src/modules/etherlink/components/EvmDelegationPrompt.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { Box, Typography, styled, useMediaQuery, useTheme, InfoOutlined } from "components/ui"
+import { Button } from "components/ui/Button"
+import { useEvmDaoOps } from "services/contracts/etherlinkDAO/hooks/useEvmDaoOps"
+
+const PromptBox = styled(Box)(({ theme }) => ({
+  display: "flex",
+  gap: 12,
+  alignItems: "flex-start",
+  background: theme.palette.warning.main,
+  borderRadius: 4,
+  padding: 16
+}))
+
+/**
+ * Governance tokens deployed by Homebase use OpenZeppelin's ERC20Votes, where holding
+ * tokens grants no voting power until the holder delegates (usually to themselves).
+ * Without this prompt, a fresh DAO creator holding the entire supply only discovers the
+ * problem after a failed proposal ("You do not meet the proposal threshold").
+ *
+ * Renders nothing unless the connected wallet actually holds tokens but has zero votes.
+ */
+export const EvmDelegationPrompt: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
+  const theme = useTheme()
+  const isMobileSmall = useMediaQuery(theme.breakpoints.down("lg"))
+  const { daoDelegate, loggedInUser, userTokenBalance, userVotingWeight, refreshTokenStats } = useEvmDaoOps()
+  const [isDelegating, setIsDelegating] = React.useState(false)
+
+  const address = loggedInUser?.address
+  const needsDelegation = !!address && (userTokenBalance || 0) > 0 && (userVotingWeight || 0) === 0
+
+  if (!needsDelegation) return null
+
+  const onActivate = () => {
+    if (!address) return
+    setIsDelegating(true)
+    daoDelegate(address)
+      .then(() => refreshTokenStats())
+      .catch(() => {
+        // daoDelegate already surfaces a notification on failure
+      })
+      .finally(() => setIsDelegating(false))
+  }
+
+  return (
+    <PromptBox
+      style={{ flexDirection: isMobileSmall ? "column" : "row", ...style }}
+      role="status"
+      data-testid="evm-delegation-prompt"
+    >
+      <InfoOutlined style={{ color: "#000", marginTop: 2 }} />
+      <Box style={{ flex: 1 }}>
+        <Typography style={{ color: "#000", fontWeight: 600 }}>Your tokens aren&apos;t delegated yet</Typography>
+        <Typography style={{ color: "#000", fontSize: 14 }}>
+          Holding tokens is not enough to vote or propose. Delegate to yourself to activate your voting power.
+        </Typography>
+      </Box>
+      <Button
+        variant="contained"
+        disabled={isDelegating}
+        onClick={onActivate}
+        style={{ whiteSpace: "nowrap", alignSelf: isMobileSmall ? "flex-start" : "center", marginRight: 0 }}
+      >
+        {isDelegating ? "Activating…" : "Activate voting power"}
+      </Button>
+    </PromptBox>
+  )
+}

--- a/src/modules/etherlink/explorer/EtherlinkDAO/EvmUserPage.tsx
+++ b/src/modules/etherlink/explorer/EtherlinkDAO/EvmUserPage.tsx
@@ -12,6 +12,7 @@ import { formatNumber } from "modules/explorer/utils/FormatNumber"
 import { FormField, FormTextField } from "components/ui"
 import { useHistory } from "react-router-dom"
 import { EvmActivityHistory } from "modules/etherlink/components/EvmActivityHistory"
+import { EvmDelegationPrompt } from "modules/etherlink/components/EvmDelegationPrompt"
 import { TokenBridge } from "modules/etherlink/bridge/TokenBridge"
 import { Item, ItemContent, ItemTitle, ItemValue, TransparentItem } from "components/ui/etherlink/Stats"
 import { DelegationBox, DelegationTitle, DelegationDescription } from "components/ui/etherlink/styled"
@@ -171,6 +172,7 @@ export const EvmUserPage = () => {
 
   return (
     <Box>
+      <EvmDelegationPrompt style={{ marginBottom: 24 }} />
       <UserProfileCard>
         <UserInfoSection>
           <ProfileAvatar address={userAddress || ""} size={50} />

--- a/src/modules/etherlink/explorer/EvmProposalsActionDialog.tsx
+++ b/src/modules/etherlink/explorer/EvmProposalsActionDialog.tsx
@@ -9,7 +9,7 @@ import { EvmResponsiveDialog } from "../components/EvmResponsiveDialog"
 import { BackButton } from "modules/lite/components/BackButton"
 
 import { useEvmProposalOps } from "services/contracts/etherlinkDAO/hooks/useEvmProposalOps"
-import { useEvmDaoOps } from "services/contracts/etherlinkDAO/hooks/useEvmDaoOps"
+import { EvmDelegationPrompt } from "../components/EvmDelegationPrompt"
 import { EtherlinkContext } from "services/wagmi/context"
 import { EvmPropTransferAssets } from "./EvmProposals/EvmPropTransferAssets"
 import { EvmPropEditRegistry } from "./EvmProposals/EvmPropEditRegistry"
@@ -49,9 +49,7 @@ export const EvmProposalsActionDialog = ({ open, handleClose }: { open: boolean;
   const theme = useTheme()
   const { isLoading, currentStep, metadata, setMetadataFieldValue, isDeploying, isNextDisabled, nextStep, prevStep } =
     useEvmProposalOps()
-  const { daoDelegate, userVotingWeight, loggedInUser, refreshTokenStats } = useEvmDaoOps()
   const { daoSelected } = useContext(EtherlinkContext)
-  const [isDelegating, setIsDelegating] = React.useState(false)
   const isMobileSmall = useMediaQuery(theme.breakpoints.down("lg"))
   const offchainEnabled = isFeatureEnabled("etherlink-offchain-debate")
 
@@ -82,6 +80,7 @@ export const EvmProposalsActionDialog = ({ open, handleClose }: { open: boolean;
   return (
     <>
       <EvmResponsiveDialog open={open} onClose={handleClose} title={"New Proposal"} template="xs">
+        <EvmDelegationPrompt />
         <TitleContainer container direction="row">
           <Typography color="textPrimary">Select Proposal Type</Typography>
         </TitleContainer>
@@ -148,40 +147,7 @@ export const EvmProposalsActionDialog = ({ open, handleClose }: { open: boolean;
             </FormField>
           </Grid>
 
-          {/* Voting power helper */}
-          <Box
-            style={{
-              display: "flex",
-              flexDirection: isMobileSmall ? "column" : "row",
-              alignItems: isMobileSmall ? "stretch" : "center",
-              gap: 8,
-              marginBottom: 24,
-              background: theme.palette.primary.main,
-              borderRadius: 4,
-              padding: 16
-            }}
-          >
-            <Typography color="textPrimary" style={{ flex: 1 }}>
-              Voting power:
-            </Typography>
-            <NextButton
-              disabled={isDelegating || !loggedInUser?.address || (userVotingWeight || 0) > 0}
-              onClick={() => {
-                if (!loggedInUser?.address) return
-                setIsDelegating(true)
-                daoDelegate(loggedInUser.address)
-                  .then(() => refreshTokenStats())
-                  .catch(() => {})
-                  .finally(() => setIsDelegating(false))
-              }}
-            >
-              {(userVotingWeight || 0) > 0
-                ? "Voting Power Ready"
-                : isDelegating
-                  ? "Delegating..."
-                  : "Self‑delegate (Claim Voting Power)"}
-            </NextButton>
-          </Box>
+          <EvmDelegationPrompt style={{ marginBottom: 24 }} />
 
           <Grid container direction="row" justifyContent="space-between" alignItems="center">
             <BackButton onClick={prevStep.handler} />


### PR DESCRIPTION
## The trap

Governance tokens deployed through Homebase use OpenZeppelin's **ERC20Votes**, where holding tokens grants **zero** voting and proposing power until the holder delegates — typically to themselves. This is a well-known ERC20Votes footgun, and it hits the worst possible user: the person who just created a DAO.

The flow today:

1. User creates a DAO and receives the entire token supply.
2. User opens "New Proposal", picks a type, writes a title and description, fills in the action.
3. User submits — and only *then* gets `You do not meet the proposal threshold`.

Nothing before that point explains delegation or offers to do it. The user holds 100% of the supply and is told they lack the power to propose, with no indication of why or what to do about it.

## Reproduction

Verified live on shadownet (2026-08-13). A scripted flow against a freshly created DAO reverts on `propose()` with `GovernorInsufficientProposerVotes` (`0xc242ee16`) despite the signer holding the full supply. Inserting a `token.delegate(self)` call before `propose()` makes the identical flow succeed. `balanceOf(signer)` is the full supply while `getVotes(signer)` is `0` until that delegate call lands.

## Why the existing helper didn't cover this

`EvmProposalsActionDialog` already had a "Voting power helper", but it was ineffective:

- It lived on **step 1**, after the user had already committed to a proposal type and typed a title — past the point where the confusion starts.
- It rendered a bare `Voting power:` label with **no value** interpolated, so it never actually told the user their power was zero.
- It rendered unconditionally, showing a self-delegate button even to users who were already delegated, which made it read as decoration rather than a required action.

There is also a preflight check in `useEvmProposalOps` that compares `getVotes()` against the threshold, but it fires at submit time and its remedy text points at another page ("Use 'Claim Voting Power' in the User tab"), so the user still loses the work they just typed.

## The fix

New `EvmDelegationPrompt` component that:

- Renders **only when it matters** — connected wallet holds tokens (`balanceOf > 0`) but has no voting power (`getVotes == 0`). Delegated users and non-holders see nothing.
- States the problem in plain language: "Your tokens aren't delegated yet — holding tokens is not enough to vote or propose."
- Offers one-click **"Activate voting power"**, calling `token.delegate(ownAddress)` through the connected signer via the existing `daoDelegate` in `useEvmDaoOps`, with pending state, notistack success/error feedback, and a `refreshTokenStats()` call so the power display updates immediately.

Placed at the **proposal-type selection step** (the real entry point, before any work is invested), retained on the proposal detail step in place of the broken helper, and added to the DAO **user page** beside the voting-weight stat.

## Notes

- Reuses the existing `daoDelegate` / `refreshTokenStats` from `useEvmDaoOps` — no new contract plumbing.
- MUI v6 components via the `components/ui` export surface, consistent with surrounding Etherlink code.
- No refactors; the diff is one new component plus its two call sites.

## Testing

Reviewers can test on shadownet:

- DAO: `0xEeDCa7F405210cBCB4E63a67F18e974c821F4Ca1`
- Token: `0x444aC1384afA71700eeBDC5d3b05256C8229F008`

Connect a wallet holding the governance token that has never delegated, open "New Proposal", and the prompt should appear immediately on the type-selection screen. Click "Activate voting power", confirm the tx, and the prompt should disappear once `getVotes()` becomes non-zero — after which proposal creation succeeds.

`npx tsc --noEmit` passes; `eslint` reports no errors on the changed files.
